### PR TITLE
feat: Selector Global de Modo de Operación — Spec 32

### DIFF
--- a/apps/api/prisma/migrations/20260413184109_add_platform_operation_mode/migration.sql
+++ b/apps/api/prisma/migrations/20260413184109_add_platform_operation_mode/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `embedding_vec` on the `agent_document_chunks` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "agent_document_chunks_embedding_vec_idx";
+
+-- AlterTable
+ALTER TABLE "agent_definitions" ALTER COLUMN "skills" DROP DEFAULT,
+ALTER COLUMN "updatedAt" DROP DEFAULT,
+ALTER COLUMN "updatedAt" SET DATA TYPE TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "agent_document_chunks" DROP COLUMN "embedding_vec",
+ALTER COLUMN "embedding" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "agent_documents" ALTER COLUMN "uploadedAt" SET DATA TYPE TIMESTAMP(3),
+ALTER COLUMN "processedAt" SET DATA TYPE TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "platformOperationMode" "TradingMode" NOT NULL DEFAULT 'SANDBOX';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -104,13 +104,14 @@ enum NewsApiProvider {
 // ── Models ───────────────────────────────────────────────
 
 model User {
-  id           String   @id @default(cuid())
-  email        String   @unique
-  passwordHash String
-  role         UserRole @default(TRADER)
-  isActive     Boolean  @default(true)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id                    String      @id @default(cuid())
+  email                 String      @unique
+  passwordHash          String
+  role                  UserRole    @default(TRADER)
+  isActive              Boolean     @default(true)
+  platformOperationMode TradingMode @default(SANDBOX)
+  createdAt             DateTime    @default(now())
+  updatedAt             DateTime    @updatedAt
 
   binanceCredentials BinanceCredential[]
   llmCredentials     LLMCredential[]

--- a/apps/api/src/auth/dto/auth.dto.ts
+++ b/apps/api/src/auth/dto/auth.dto.ts
@@ -4,6 +4,7 @@ import {
   MinLength,
   IsOptional,
   IsBoolean,
+  IsEnum,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
@@ -109,4 +110,14 @@ export class NewsApiKeyDto {
   @ApiProperty({ description: 'API Key del proveedor de noticias' })
   @IsString()
   apiKey!: string;
+}
+
+export class UpdateOperationModeDto {
+  @ApiProperty({
+    enum: ['SANDBOX', 'TESTNET', 'LIVE'],
+    example: 'SANDBOX',
+    description: 'Modo de operación global de la plataforma',
+  })
+  @IsEnum(['SANDBOX', 'TESTNET', 'LIVE'])
+  mode!: 'SANDBOX' | 'TESTNET' | 'LIVE';
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -26,6 +26,7 @@ import {
   LLMKeyDto,
   NewsApiKeyDto,
   UpdateUserStatusDto,
+  UpdateOperationModeDto,
 } from '../auth/dto/auth.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -58,6 +59,28 @@ export class UsersController {
   @ApiResponse({ status: 409, description: 'Email ya en uso' })
   updateMe(@CurrentUser() user: RequestUser, @Body() dto: UpdateUserDto) {
     return this.usersService.updateMe(user.userId, dto);
+  }
+
+  // ── /users/me/operation-mode ──────────────────────────────────────────────
+
+  @Patch('users/me/operation-mode')
+  @ApiOperation({
+    summary:
+      'Actualizar el modo de operación global de la plataforma (SANDBOX / TESTNET / LIVE)',
+  })
+  @ApiResponse({
+    status: 200,
+    schema: { example: { platformOperationMode: 'SANDBOX' } },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Claves API no configuradas para el modo solicitado',
+  })
+  updateOperationMode(
+    @CurrentUser() user: RequestUser,
+    @Body() dto: UpdateOperationModeDto,
+  ) {
+    return this.usersService.updateOperationMode(user.userId, dto);
   }
 
   // ── /users/me/binance-keys ────────────────────────────────────────────────

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { PrismaService } from '../prisma/prisma.service';
 
@@ -182,6 +182,98 @@ describe('UsersService', () => {
       await expect(
         service.setUserStatus('admin-1', 'fake', true),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateOperationMode', () => {
+    it('should allow switching to SANDBOX without any key check', async () => {
+      prisma.user.update.mockResolvedValue({
+        id: 'user-1',
+        platformOperationMode: 'SANDBOX',
+      });
+
+      const result = await service.updateOperationMode('user-1', {
+        mode: 'SANDBOX',
+      });
+      expect(result).toEqual({ platformOperationMode: 'SANDBOX' });
+      expect(prisma.binanceCredential.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when switching to LIVE without production keys', async () => {
+      prisma.binanceCredential.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateOperationMode('user-1', { mode: 'LIVE' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should allow switching to LIVE when production keys exist', async () => {
+      prisma.binanceCredential.findUnique.mockResolvedValue({
+        id: 'cred-1',
+        isTestnet: false,
+        isActive: true,
+      });
+      prisma.user.update.mockResolvedValue({
+        id: 'user-1',
+        platformOperationMode: 'LIVE',
+      });
+
+      const result = await service.updateOperationMode('user-1', {
+        mode: 'LIVE',
+      });
+      expect(result).toEqual({ platformOperationMode: 'LIVE' });
+      expect(prisma.binanceCredential.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId_isTestnet: { userId: 'user-1', isTestnet: false } },
+        }),
+      );
+    });
+
+    it('should throw BadRequestException when switching to TESTNET without testnet keys', async () => {
+      prisma.binanceCredential.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateOperationMode('user-1', { mode: 'TESTNET' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should allow switching to TESTNET when testnet keys exist', async () => {
+      prisma.binanceCredential.findUnique.mockResolvedValue({
+        id: 'cred-2',
+        isTestnet: true,
+        isActive: true,
+      });
+      prisma.user.update.mockResolvedValue({
+        id: 'user-1',
+        platformOperationMode: 'TESTNET',
+      });
+
+      const result = await service.updateOperationMode('user-1', {
+        mode: 'TESTNET',
+      });
+      expect(result).toEqual({ platformOperationMode: 'TESTNET' });
+      expect(prisma.binanceCredential.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId_isTestnet: { userId: 'user-1', isTestnet: true } },
+        }),
+      );
+    });
+  });
+
+  describe('getMe', () => {
+    it('should include platformOperationMode in the response', async () => {
+      const user = {
+        id: 'user-1',
+        email: 'test@test.com',
+        role: 'TRADER',
+        isActive: true,
+        platformOperationMode: 'SANDBOX',
+        createdAt: new Date(),
+      };
+      prisma.user.findUnique.mockResolvedValue(user);
+
+      const result = await service.getMe('user-1');
+      expect(result).toHaveProperty('platformOperationMode', 'SANDBOX');
     });
   });
 });

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -31,8 +31,7 @@ describe('UsersService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    process.env.BINANCE_KEY_ENCRYPTION_KEY =
-      'dev-encryption-key-32-chars-long';
+    process.env.BINANCE_KEY_ENCRYPTION_KEY = 'dev-encryption-key-32-chars-long';
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UsersService,

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   ConflictException,
   ForbiddenException,
+  BadRequestException,
 } from '@nestjs/common';
 import bcrypt from 'bcrypt';
 import axios from 'axios';
@@ -13,6 +14,7 @@ import {
   SetTestnetBinanceKeysDto,
   LLMKeyDto,
   NewsApiKeyDto,
+  UpdateOperationModeDto,
 } from '../auth/dto/auth.dto';
 import { encrypt, decrypt } from './utils/encryption.util';
 import { LLMProvider, NewsApiProvider } from '../../generated/prisma/enums';
@@ -31,6 +33,7 @@ export class UsersService {
         email: true,
         role: true,
         isActive: true,
+        platformOperationMode: true,
         createdAt: true,
       },
     });
@@ -47,6 +50,41 @@ export class UsersService {
       data,
       select: { id: true, email: true, role: true, updatedAt: true },
     });
+  }
+
+  // ── Operation mode ─────────────────────────────────────────────────────────
+
+  async updateOperationMode(userId: string, dto: UpdateOperationModeDto) {
+    const { mode } = dto;
+
+    if (mode === 'LIVE') {
+      const cred = await this.prisma.binanceCredential.findUnique({
+        where: { userId_isTestnet: { userId, isTestnet: false } },
+      });
+      if (!cred) {
+        throw new BadRequestException(
+          'No Binance production keys configured. Add your API keys in Settings first.',
+        );
+      }
+    }
+
+    if (mode === 'TESTNET') {
+      const cred = await this.prisma.binanceCredential.findUnique({
+        where: { userId_isTestnet: { userId, isTestnet: true } },
+      });
+      if (!cred) {
+        throw new BadRequestException(
+          'No Binance testnet keys configured. Add your testnet API keys in Settings first.',
+        );
+      }
+    }
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { platformOperationMode: mode },
+    });
+
+    return { platformOperationMode: mode };
   }
 
   // ── Binance credentials ────────────────────────────────────────────────────

--- a/apps/web/src/components/dashboard-header.tsx
+++ b/apps/web/src/components/dashboard-header.tsx
@@ -6,6 +6,7 @@ import { useSidebarStore } from '../store/sidebar.store';
 import { AvatarDropdown } from './avatar-dropdown';
 import { Link } from 'react-router-dom';
 import { ConnectionStatusDropdown } from './connection-status-dropdown';
+import { ModeSelector } from './mode-selector';
 
 export function DashboardHeader() {
   const unreadCount = useUnreadCount();
@@ -34,6 +35,9 @@ export function DashboardHeader() {
       <div className="flex items-center gap-1.5">
         {/* Connection status */}
         <ConnectionStatusDropdown />
+
+        {/* Operation mode selector */}
+        <ModeSelector />
 
         {/* Notifications bell */}
         <div className="relative border border-border rounded-md">

--- a/apps/web/src/components/mode-selector.tsx
+++ b/apps/web/src/components/mode-selector.tsx
@@ -1,0 +1,360 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useNavigate } from 'react-router-dom';
+import { FlaskConical, TestTube, Activity, Lock, ChevronDown, AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { cn } from '../lib/utils';
+import type { TradingMode } from '../hooks/use-user';
+import {
+  usePlatformMode,
+  useUpdatePlatformMode,
+} from '../hooks/use-user';
+
+// ── Config por modo ───────────────────────────────────────────────────────────
+
+const MODE_CONFIG: Record<
+  TradingMode,
+  {
+    icon: React.ElementType;
+    label: string;
+    descKey: string;
+    badgeClass: string;
+    dotClass: string;
+  }
+> = {
+  SANDBOX: {
+    icon: FlaskConical,
+    label: 'Sandbox',
+    descKey: 'modeSelector.sandboxDesc',
+    badgeClass: 'bg-yellow-500/15 text-yellow-600 border-yellow-500/30 dark:text-yellow-400',
+    dotClass: 'bg-yellow-500',
+  },
+  TESTNET: {
+    icon: TestTube,
+    label: 'Testnet',
+    descKey: 'modeSelector.testnetDesc',
+    badgeClass: 'bg-orange-500/15 text-orange-600 border-orange-500/30 dark:text-orange-400',
+    dotClass: 'bg-orange-500',
+  },
+  LIVE: {
+    icon: Activity,
+    label: 'En Vivo',
+    descKey: 'modeSelector.liveDesc',
+    badgeClass: 'bg-green-500/15 text-green-600 border-green-500/30 dark:text-green-400',
+    dotClass: 'bg-green-500 animate-pulse',
+  },
+};
+
+const ALL_MODES: TradingMode[] = ['SANDBOX', 'TESTNET', 'LIVE'];
+
+// ── CredentialsRequiredModal ──────────────────────────────────────────────────
+
+interface CredentialsModalProps {
+  mode: TradingMode;
+  onClose: () => void;
+}
+
+function CredentialsRequiredModal({ mode, onClose }: CredentialsModalProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const cfg = MODE_CONFIG[mode];
+  const Icon = cfg.icon;
+
+  const descKey =
+    mode === 'TESTNET'
+      ? 'modeSelector.credentialsModalTestnetDesc'
+      : 'modeSelector.credentialsModalLiveDesc';
+
+  const tabTarget =
+    mode === 'TESTNET' ? 'binance-testnet' : 'binance';
+
+  function handleAddCredentials() {
+    onClose();
+    navigate(`/dashboard/settings?tab=${tabTarget}`);
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-card border border-border rounded-xl shadow-xl w-full max-w-sm mx-4 p-6 flex flex-col gap-4">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <div className={cn('p-2 rounded-lg border', cfg.badgeClass)}>
+            <Icon className="h-5 w-5" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-foreground text-sm">
+              {t('modeSelector.credentialsModalTitle', { mode: cfg.label })}
+            </h3>
+            {mode === 'LIVE' && (
+              <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
+                <AlertTriangle className="h-3 w-3 text-orange-500" />
+                {t('modeSelector.liveWarningShort', 'Dinero real')}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Body */}
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {t(descKey)}
+        </p>
+
+        {/* Actions */}
+        <div className="flex gap-2 pt-1">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 text-sm font-medium rounded-lg border border-border text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            {t('modeSelector.credentialsModalCancel', 'Cancelar')}
+          </button>
+          <button
+            onClick={handleAddCredentials}
+            className="flex-1 px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            {t('modeSelector.credentialsModalCta', 'Agregar Credenciales')}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ── ConfirmLiveModal ──────────────────────────────────────────────────────────
+
+interface ConfirmLiveModalProps {
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+function ConfirmLiveModal({ onConfirm, onClose }: ConfirmLiveModalProps) {
+  const { t } = useTranslation();
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-card border border-border rounded-xl shadow-xl w-full max-w-sm mx-4 p-6 flex flex-col gap-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg border bg-red-500/15 text-red-600 border-red-500/30">
+            <AlertTriangle className="h-5 w-5" />
+          </div>
+          <h3 className="font-semibold text-foreground text-sm">
+            {t('modeSelector.switchConfirmTitle', 'Cambiar a modo En Vivo')}
+          </h3>
+        </div>
+
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {t(
+            'modeSelector.switchConfirmDesc',
+            'Estás a punto de cambiar al modo EN VIVO. Las operaciones afectarán fondos reales en Binance.',
+          )}
+        </p>
+
+        <div className="flex gap-2 pt-1">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 text-sm font-medium rounded-lg border border-border text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            {t('common.cancel', 'Cancelar')}
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 px-4 py-2 text-sm font-medium rounded-lg bg-red-600 text-white hover:bg-red-700 transition-colors"
+          >
+            {t('modeSelector.confirmLive', 'Sí, cambiar a En Vivo')}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ── ModeSelector ──────────────────────────────────────────────────────────────
+
+export function ModeSelector() {
+  const { t } = useTranslation();
+  const { mode, availableModes, isLoading } = usePlatformMode();
+  const updateMode = useUpdatePlatformMode();
+
+  const [open, setOpen] = useState(false);
+  const [credentialsModal, setCredentialsModal] = useState<TradingMode | null>(null);
+  const [confirmLive, setConfirmLive] = useState(false);
+
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [coords, setCoords] = useState({ top: 0, left: 0 });
+
+  // Cerrar al hacer click fuera
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  function handleToggle() {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setCoords({ top: rect.bottom + 6, left: rect.left });
+    }
+    setOpen((v) => !v);
+  }
+
+  function handleModeClick(target: TradingMode) {
+    if (target === mode) {
+      setOpen(false);
+      return;
+    }
+
+    // Modo no disponible → modal de credenciales
+    if (!availableModes.includes(target)) {
+      setOpen(false);
+      setCredentialsModal(target);
+      return;
+    }
+
+    // LIVE requiere confirmación
+    if (target === 'LIVE') {
+      setOpen(false);
+      setConfirmLive(true);
+      return;
+    }
+
+    // SANDBOX / TESTNET → cambio directo
+    doSwitch(target);
+    setOpen(false);
+  }
+
+  function doSwitch(target: TradingMode) {
+    updateMode.mutate(target, {
+      onSuccess: () => {
+        toast.success(
+          t('modeSelector.switchedSuccess', { mode: MODE_CONFIG[target].label }),
+        );
+      },
+    });
+  }
+
+  if (isLoading) return null;
+
+  const activeCfg = MODE_CONFIG[mode];
+  const ActiveIcon = activeCfg.icon;
+
+  return (
+    <>
+      {/* Trigger badge */}
+      <button
+        ref={triggerRef}
+        onClick={handleToggle}
+        disabled={updateMode.isPending}
+        className={cn(
+          'flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border text-xs font-medium transition-all',
+          'hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          activeCfg.badgeClass,
+          updateMode.isPending && 'opacity-50 cursor-not-allowed',
+        )}
+        aria-label={t('modeSelector.label', 'Modo de operación')}
+      >
+        <span className={cn('h-1.5 w-1.5 rounded-full', activeCfg.dotClass)} />
+        <ActiveIcon className="h-3.5 w-3.5" />
+        <span>{activeCfg.label}</span>
+        <ChevronDown
+          className={cn(
+            'h-3 w-3 transition-transform duration-150',
+            open && 'rotate-180',
+          )}
+        />
+      </button>
+
+      {/* Dropdown por portal */}
+      {open &&
+        createPortal(
+          <div
+            ref={dropdownRef}
+            style={{ top: coords.top, left: coords.left }}
+            className="fixed z-[100] w-52 rounded-xl border border-border bg-popover shadow-lg overflow-hidden"
+          >
+            <div className="px-3 py-2 border-b border-border">
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                {t('modeSelector.label', 'Modo de operación')}
+              </p>
+            </div>
+            <div className="p-1">
+              {ALL_MODES.map((m) => {
+                const cfg = MODE_CONFIG[m];
+                const Icon = cfg.icon;
+                const isActive = m === mode;
+                const isAvailable = availableModes.includes(m);
+
+                return (
+                  <button
+                    key={m}
+                    onClick={() => handleModeClick(m)}
+                    className={cn(
+                      'w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-left text-sm transition-colors',
+                      isActive
+                        ? cn('font-medium', cfg.badgeClass)
+                        : 'text-foreground hover:bg-muted',
+                      !isAvailable && !isActive && 'opacity-50',
+                    )}
+                  >
+                    <Icon className="h-4 w-4 shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <span className="block truncate">{cfg.label}</span>
+                    </div>
+                    {isActive && (
+                      <span className={cn('h-1.5 w-1.5 rounded-full shrink-0', cfg.dotClass)} />
+                    )}
+                    {!isAvailable && !isActive && (
+                      <Lock className="h-3 w-3 text-muted-foreground shrink-0" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>,
+          document.body,
+        )}
+
+      {/* Modal credenciales requeridas */}
+      {credentialsModal && (
+        <CredentialsRequiredModal
+          mode={credentialsModal}
+          onClose={() => setCredentialsModal(null)}
+        />
+      )}
+
+      {/* Modal confirmación LIVE */}
+      {confirmLive && (
+        <ConfirmLiveModal
+          onConfirm={() => {
+            setConfirmLive(false);
+            doSwitch('LIVE');
+          }}
+          onClose={() => setConfirmLive(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/mode-selector.tsx
+++ b/apps/web/src/components/mode-selector.tsx
@@ -1,15 +1,19 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { FlaskConical, TestTube, Activity, Lock, ChevronDown, AlertTriangle } from 'lucide-react';
+import {
+  FlaskConical,
+  TestTube,
+  Activity,
+  Lock,
+  ChevronDown,
+  AlertTriangle,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { cn } from '../lib/utils';
 import type { TradingMode } from '../hooks/use-user';
-import {
-  usePlatformMode,
-  useUpdatePlatformMode,
-} from '../hooks/use-user';
+import { usePlatformMode, useUpdatePlatformMode } from '../hooks/use-user';
 
 // ── Config por modo ───────────────────────────────────────────────────────────
 
@@ -27,21 +31,24 @@ const MODE_CONFIG: Record<
     icon: FlaskConical,
     label: 'Sandbox',
     descKey: 'modeSelector.sandboxDesc',
-    badgeClass: 'bg-yellow-500/15 text-yellow-600 border-yellow-500/30 dark:text-yellow-400',
+    badgeClass:
+      'bg-yellow-500/15 text-yellow-600 border-yellow-500/30 dark:text-yellow-400',
     dotClass: 'bg-yellow-500',
   },
   TESTNET: {
     icon: TestTube,
     label: 'Testnet',
     descKey: 'modeSelector.testnetDesc',
-    badgeClass: 'bg-orange-500/15 text-orange-600 border-orange-500/30 dark:text-orange-400',
+    badgeClass:
+      'bg-orange-500/15 text-orange-600 border-orange-500/30 dark:text-orange-400',
     dotClass: 'bg-orange-500',
   },
   LIVE: {
     icon: Activity,
     label: 'En Vivo',
     descKey: 'modeSelector.liveDesc',
-    badgeClass: 'bg-green-500/15 text-green-600 border-green-500/30 dark:text-green-400',
+    badgeClass:
+      'bg-green-500/15 text-green-600 border-green-500/30 dark:text-green-400',
     dotClass: 'bg-green-500 animate-pulse',
   },
 };
@@ -66,8 +73,7 @@ function CredentialsRequiredModal({ mode, onClose }: CredentialsModalProps) {
       ? 'modeSelector.credentialsModalTestnetDesc'
       : 'modeSelector.credentialsModalLiveDesc';
 
-  const tabTarget =
-    mode === 'TESTNET' ? 'binance-testnet' : 'binance';
+  const tabTarget = mode === 'TESTNET' ? 'binance-testnet' : 'binance';
 
   function handleAddCredentials() {
     onClose();
@@ -188,7 +194,9 @@ export function ModeSelector() {
   const updateMode = useUpdatePlatformMode();
 
   const [open, setOpen] = useState(false);
-  const [credentialsModal, setCredentialsModal] = useState<TradingMode | null>(null);
+  const [credentialsModal, setCredentialsModal] = useState<TradingMode | null>(
+    null,
+  );
   const [confirmLive, setConfirmLive] = useState(false);
 
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -250,7 +258,9 @@ export function ModeSelector() {
     updateMode.mutate(target, {
       onSuccess: () => {
         toast.success(
-          t('modeSelector.switchedSuccess', { mode: MODE_CONFIG[target].label }),
+          t('modeSelector.switchedSuccess', {
+            mode: MODE_CONFIG[target].label,
+          }),
         );
       },
     });
@@ -324,7 +334,12 @@ export function ModeSelector() {
                       <span className="block truncate">{cfg.label}</span>
                     </div>
                     {isActive && (
-                      <span className={cn('h-1.5 w-1.5 rounded-full shrink-0', cfg.dotClass)} />
+                      <span
+                        className={cn(
+                          'h-1.5 w-1.5 rounded-full shrink-0',
+                          cfg.dotClass,
+                        )}
+                      />
                     )}
                     {!isAvailable && !isActive && (
                       <Lock className="h-3 w-3 text-muted-foreground shrink-0" />

--- a/apps/web/src/hooks/use-analytics.ts
+++ b/apps/web/src/hooks/use-analytics.ts
@@ -17,7 +17,7 @@ export interface Trade {
   quantity: number;
   fee: number;
   executedAt: string;
-  mode: 'LIVE' | 'PAPER' | 'SANDBOX';
+  mode: 'LIVE' | 'PAPER' | 'SANDBOX' | 'TESTNET';
   position?: {
     asset: string;
     pair: string;

--- a/apps/web/src/hooks/use-user.ts
+++ b/apps/web/src/hooks/use-user.ts
@@ -3,11 +3,14 @@ import { api } from '../lib/api';
 import { useAuthStore } from '../store/auth.store';
 import { toast } from 'sonner';
 
+export type TradingMode = 'SANDBOX' | 'TESTNET' | 'LIVE';
+
 export interface UserProfile {
   id: string;
   email: string;
   role: string;
   isActive: boolean;
+  platformOperationMode: TradingMode;
   createdAt: string;
 }
 
@@ -278,5 +281,44 @@ export function useNewsSourcesStatus() {
     queryFn: () => api.get<NewsSourceStatus[]>('/market/news-sources/status'),
     staleTime: 60_000,
     enabled: isAuthenticated,
+  });
+}
+
+// ── Platform operation mode ────────────────────────────────────────────────
+
+export function usePlatformMode() {
+  const { data: profile, isLoading } = useUserProfile();
+  const { data: liveKeyStatus } = useBinanceKeyStatus();
+  const { data: testnetKeyStatus } = useTestnetBinanceKeyStatus();
+
+  const mode: TradingMode = profile?.platformOperationMode ?? 'SANDBOX';
+
+  const availableModes: TradingMode[] = ['SANDBOX'];
+  if (testnetKeyStatus?.hasKeys) availableModes.push('TESTNET');
+  if (liveKeyStatus?.hasKeys) availableModes.push('LIVE');
+
+  return {
+    mode,
+    isSandbox: mode === 'SANDBOX',
+    isTestnet: mode === 'TESTNET',
+    isLive: mode === 'LIVE',
+    availableModes,
+    isLoading,
+  };
+}
+
+export function useUpdatePlatformMode() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (mode: TradingMode) =>
+      api.patch<{ platformOperationMode: TradingMode }>(
+        '/users/me/operation-mode',
+        { mode },
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['user', 'profile'] });
+    },
+    onError: (err: { message?: string }) =>
+      toast.error(err?.message || 'Error al cambiar el modo de operación'),
   });
 }

--- a/apps/web/src/hooks/use-user.ts
+++ b/apps/web/src/hooks/use-user.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { useAuthStore } from '../store/auth.store';
@@ -286,27 +287,6 @@ export function useNewsSourcesStatus() {
 
 // ── Platform operation mode ────────────────────────────────────────────────
 
-export function usePlatformMode() {
-  const { data: profile, isLoading } = useUserProfile();
-  const { data: liveKeyStatus } = useBinanceKeyStatus();
-  const { data: testnetKeyStatus } = useTestnetBinanceKeyStatus();
-
-  const mode: TradingMode = profile?.platformOperationMode ?? 'SANDBOX';
-
-  const availableModes: TradingMode[] = ['SANDBOX'];
-  if (testnetKeyStatus?.hasKeys) availableModes.push('TESTNET');
-  if (liveKeyStatus?.hasKeys) availableModes.push('LIVE');
-
-  return {
-    mode,
-    isSandbox: mode === 'SANDBOX',
-    isTestnet: mode === 'TESTNET',
-    isLive: mode === 'LIVE',
-    availableModes,
-    isLoading,
-  };
-}
-
 export function useUpdatePlatformMode() {
   const qc = useQueryClient();
   return useMutation({
@@ -321,4 +301,40 @@ export function useUpdatePlatformMode() {
     onError: (err: { message?: string }) =>
       toast.error(err?.message || 'Error al cambiar el modo de operación'),
   });
+}
+
+export function usePlatformMode() {
+  const { data: profile, isLoading } = useUserProfile();
+  const { data: liveKeyStatus } = useBinanceKeyStatus();
+  const { data: testnetKeyStatus } = useTestnetBinanceKeyStatus();
+  const updateMode = useUpdatePlatformMode();
+
+  const mode: TradingMode = profile?.platformOperationMode ?? 'SANDBOX';
+
+  const availableModes: TradingMode[] = ['SANDBOX'];
+  if (testnetKeyStatus?.hasKeys) availableModes.push('TESTNET');
+  if (liveKeyStatus?.hasKeys) availableModes.push('LIVE');
+
+  // Fallback automático a SANDBOX si el modo activo ya no tiene keys configuradas
+  useEffect(() => {
+    if (!isLoading && mode !== 'SANDBOX' && !availableModes.includes(mode)) {
+      updateMode.mutate('SANDBOX', {
+        onSuccess: () => {
+          toast.warning(
+            `Modo ${mode} no disponible. Cambiado a Sandbox automáticamente.`,
+          );
+        },
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, isLoading, availableModes.join(',')]);
+
+  return {
+    mode,
+    isSandbox: mode === 'SANDBOX',
+    isTestnet: mode === 'TESTNET',
+    isLive: mode === 'LIVE',
+    availableModes,
+    isLoading,
+  };
 }

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -1448,7 +1448,8 @@ const en = {
       'You are about to switch to LIVE mode. All operations will affect real funds on Binance.',
     confirmLive: 'Yes, switch to Live',
     switchedSuccess: 'Mode switched to {{mode}}',
-    fallbackNotice: 'Mode {{mode}} unavailable. Switched to Sandbox automatically.',
+    fallbackNotice:
+      'Mode {{mode}} unavailable. Switched to Sandbox automatically.',
     credentialsModalTitle: 'Mode {{mode}} not configured',
     credentialsModalTestnetDesc:
       'To operate in Testnet mode you need to configure your Binance Testnet API keys. Get them for free at testnet.binance.vision (no real money).',

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -1434,6 +1434,29 @@ const en = {
     currentState: 'Current state',
     noDecisionsYet: 'The agent has not made any decisions yet.',
   },
+  modeSelector: {
+    label: 'Operation mode',
+    sandbox: 'Sandbox',
+    testnet: 'Testnet',
+    live: 'Live',
+    sandboxDesc: 'Paper trading with virtual funds. No real risk.',
+    testnetDesc: 'Real orders on Binance Testnet. No real money involved.',
+    liveDesc: '⚠️ Real money. Real orders on Binance.',
+    liveWarningShort: 'Real money',
+    switchConfirmTitle: 'Switch to Live mode',
+    switchConfirmDesc:
+      'You are about to switch to LIVE mode. All operations will affect real funds on Binance.',
+    confirmLive: 'Yes, switch to Live',
+    switchedSuccess: 'Mode switched to {{mode}}',
+    fallbackNotice: 'Mode {{mode}} unavailable. Switched to Sandbox automatically.',
+    credentialsModalTitle: 'Mode {{mode}} not configured',
+    credentialsModalTestnetDesc:
+      'To operate in Testnet mode you need to configure your Binance Testnet API keys. Get them for free at testnet.binance.vision (no real money).',
+    credentialsModalLiveDesc:
+      'To operate in Live mode you need to configure your Binance API keys. ⚠️ This mode uses real funds.',
+    credentialsModalCancel: 'Cancel',
+    credentialsModalCta: 'Add Credentials',
+  },
 };
 
 export default en;

--- a/apps/web/src/locales/es.ts
+++ b/apps/web/src/locales/es.ts
@@ -1473,7 +1473,8 @@ const es = {
       'Estás a punto de cambiar al modo EN VIVO. Las operaciones afectarán fondos reales en Binance.',
     confirmLive: 'Sí, cambiar a En Vivo',
     switchedSuccess: 'Modo cambiado a {{mode}}',
-    fallbackNotice: 'Modo {{mode}} no disponible. Cambiado a Sandbox automáticamente.',
+    fallbackNotice:
+      'Modo {{mode}} no disponible. Cambiado a Sandbox automáticamente.',
     credentialsModalTitle: 'Modo {{mode}} no configurado',
     credentialsModalTestnetDesc:
       'Para operar en modo Testnet necesitás configurar tus claves API de Binance Testnet. Obtenelas gratis en testnet.binance.vision (sin dinero real).',

--- a/apps/web/src/locales/es.ts
+++ b/apps/web/src/locales/es.ts
@@ -1459,6 +1459,29 @@ const es = {
     currentState: 'Estado actual',
     noDecisionsYet: 'El agente aún no ha tomado ninguna decisión.',
   },
+  modeSelector: {
+    label: 'Modo de operación',
+    sandbox: 'Sandbox',
+    testnet: 'Testnet',
+    live: 'En Vivo',
+    sandboxDesc: 'Simulación con fondos virtuales. Sin riesgo real.',
+    testnetDesc: 'Órdenes reales en red de prueba de Binance. Sin dinero real.',
+    liveDesc: '⚠️ Dinero real. Órdenes reales en Binance.',
+    liveWarningShort: 'Dinero real',
+    switchConfirmTitle: 'Cambiar a modo En Vivo',
+    switchConfirmDesc:
+      'Estás a punto de cambiar al modo EN VIVO. Las operaciones afectarán fondos reales en Binance.',
+    confirmLive: 'Sí, cambiar a En Vivo',
+    switchedSuccess: 'Modo cambiado a {{mode}}',
+    fallbackNotice: 'Modo {{mode}} no disponible. Cambiado a Sandbox automáticamente.',
+    credentialsModalTitle: 'Modo {{mode}} no configurado',
+    credentialsModalTestnetDesc:
+      'Para operar en modo Testnet necesitás configurar tus claves API de Binance Testnet. Obtenelas gratis en testnet.binance.vision (sin dinero real).',
+    credentialsModalLiveDesc:
+      'Para operar en modo En Vivo necesitás configurar tus claves API de Binance. ⚠️ Este modo opera con fondos reales.',
+    credentialsModalCancel: 'Cancelar',
+    credentialsModalCta: 'Agregar Credenciales',
+  },
 };
 
 export default es;

--- a/apps/web/src/pages/dashboard/agent-log.tsx
+++ b/apps/web/src/pages/dashboard/agent-log.tsx
@@ -34,6 +34,7 @@ import {
   type AgentDecisionConfigDetails,
 } from '../../hooks/use-analytics';
 import { useCountdown } from './bot-analysis';
+import { usePlatformMode } from '../../hooks/use-user';
 
 gsap.registerPlugin(useGSAP);
 
@@ -1029,6 +1030,7 @@ function DecisionDetailModal({
 export function AgentLogPage() {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
+  const { mode: platformMode } = usePlatformMode();
 
   const PAGE_SIZE = 10;
   const { data: allDecisions = [], isLoading } = useAgentDecisions(200);
@@ -1039,6 +1041,19 @@ export function AgentLogPage() {
   const [selectedDecision, setSelectedDecision] =
     useState<AgentDecision | null>(null);
   const [page, setPage] = useState(1);
+
+  // Resetear página al cambiar modo global
+  useEffect(() => {
+    setPage(1);
+  }, [platformMode]);
+
+  // Filtrar por modo de plataforma activo
+  const modeFilteredDecisions = useMemo(() => {
+    return allDecisions.filter((d) => {
+      if (platformMode === 'SANDBOX') return d.mode === 'SANDBOX' || d.mode === 'PAPER';
+      return d.mode === platformMode;
+    });
+  }, [allDecisions, platformMode]);
 
   const setDecisionFilterAndReset = (v: DecisionFilter) => {
     setDecisionFilter(v);
@@ -1058,7 +1073,7 @@ export function AgentLogPage() {
     const opts: { key: string; label: string }[] = [
       { key: 'ALL', label: 'All' },
     ];
-    allDecisions.forEach((d) => {
+    modeFilteredDecisions.forEach((d) => {
       const key = `${d.asset}/${d.pair}`;
       if (!seen.has(key)) {
         seen.add(key);
@@ -1066,24 +1081,24 @@ export function AgentLogPage() {
       }
     });
     return opts;
-  }, [allDecisions]);
+  }, [modeFilteredDecisions]);
 
   const agentOptions = useMemo(() => {
     const seen = new Set<string>();
     const opts: { key: string; label: string }[] = [
       { key: 'ALL', label: 'All' },
     ];
-    allDecisions.forEach((d) => {
+    modeFilteredDecisions.forEach((d) => {
       if (d.configId && !seen.has(d.configId)) {
         seen.add(d.configId);
         opts.push({ key: d.configId, label: d.configName ?? d.configId });
       }
     });
     return opts;
-  }, [allDecisions]);
+  }, [modeFilteredDecisions]);
 
   const filtered = useMemo(() => {
-    return allDecisions.filter((d) => {
+    return modeFilteredDecisions.filter((d) => {
       if (decisionFilter !== 'ALL' && d.decision !== decisionFilter)
         return false;
       if (assetFilter !== 'ALL' && `${d.asset}/${d.pair}` !== assetFilter)
@@ -1091,7 +1106,7 @@ export function AgentLogPage() {
       if (agentFilter !== 'ALL' && d.configId !== agentFilter) return false;
       return true;
     });
-  }, [allDecisions, decisionFilter, assetFilter, agentFilter]);
+  }, [modeFilteredDecisions, decisionFilter, assetFilter, agentFilter]);
 
   const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
   const paginated = useMemo(() => {

--- a/apps/web/src/pages/dashboard/agent-log.tsx
+++ b/apps/web/src/pages/dashboard/agent-log.tsx
@@ -1050,7 +1050,8 @@ export function AgentLogPage() {
   // Filtrar por modo de plataforma activo
   const modeFilteredDecisions = useMemo(() => {
     return allDecisions.filter((d) => {
-      if (platformMode === 'SANDBOX') return d.mode === 'SANDBOX' || d.mode === 'PAPER';
+      if (platformMode === 'SANDBOX')
+        return d.mode === 'SANDBOX' || d.mode === 'PAPER';
       return d.mode === platformMode;
     });
   }, [allDecisions, platformMode]);

--- a/apps/web/src/pages/dashboard/config.tsx
+++ b/apps/web/src/pages/dashboard/config.tsx
@@ -45,7 +45,10 @@ import {
   type TradingPair,
   type IntervalMode,
 } from '../../hooks/use-trading';
-import { useTestnetBinanceKeyStatus, usePlatformMode } from '../../hooks/use-user';
+import {
+  useTestnetBinanceKeyStatus,
+  usePlatformMode,
+} from '../../hooks/use-user';
 import {
   StrategyPresets,
   PRESETS,

--- a/apps/web/src/pages/dashboard/config.tsx
+++ b/apps/web/src/pages/dashboard/config.tsx
@@ -45,7 +45,7 @@ import {
   type TradingPair,
   type IntervalMode,
 } from '../../hooks/use-trading';
-import { useTestnetBinanceKeyStatus } from '../../hooks/use-user';
+import { useTestnetBinanceKeyStatus, usePlatformMode } from '../../hooks/use-user';
 import {
   StrategyPresets,
   PRESETS,
@@ -486,9 +486,11 @@ function StepperSlider({
 function NewAgentStepperModal({
   onClose,
   onCreated,
+  defaultMode = 'SANDBOX',
 }: {
   onClose: () => void;
   onCreated: () => void;
+  defaultMode?: TradingMode;
 }) {
   const { t } = useTranslation();
   const [stepIdx, setStepIdx] = useState(0);
@@ -498,6 +500,7 @@ function NewAgentStepperModal({
   const [form, setForm] = useState<ConfigForm>({
     ...DEFAULT_FORM,
     ...PRESETS.balanced,
+    mode: defaultMode,
   });
   const { mutate: createConfig, isPending } = useCreateConfig();
   const { data: testnetKeyStatus } = useTestnetBinanceKeyStatus();
@@ -1630,6 +1633,7 @@ function DeleteAgentModal({
 
 export function ConfigPage() {
   const { t } = useTranslation();
+  const { mode: platformMode } = usePlatformMode();
   const [selectedConfig, setSelectedConfig] = useState<TradingConfig | null>(
     null,
   );
@@ -1879,6 +1883,7 @@ export function ConfigPage() {
         <NewAgentStepperModal
           onClose={() => setStepperOpen(false)}
           onCreated={() => setStepperOpen(false)}
+          defaultMode={platformMode}
         />
       )}
 

--- a/apps/web/src/pages/dashboard/positions.tsx
+++ b/apps/web/src/pages/dashboard/positions.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../hooks/use-trading';
 import { useLivePrices, calcUnrealizedPnl } from '../../hooks/use-live-prices';
 import { useMarketStore } from '../../store/market.store';
+import { usePlatformMode } from '../../hooks/use-user';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 
 const PAGE_SIZE = 20;
@@ -598,6 +599,7 @@ function LivePnlCell({ pos }: { pos: TradingPosition }) {
 
 export function PositionsPage() {
   const { t } = useTranslation();
+  const { mode: platformMode } = usePlatformMode();
   const [page, setPage] = useState(1);
   const [tab, setTab] = useState<StatusTab>('OPEN');
   const [confirmPos, setConfirmPos] = useState<TradingPosition | null>(null);
@@ -605,9 +607,20 @@ export function PositionsPage() {
   const containerRef = useRef<HTMLDivElement>(null);
   const { data, isLoading } = usePositions(page, PAGE_SIZE, tab);
   const closePosition = useClosePosition();
-  const positions = data?.positions ?? [];
+
+  // Resetear página al cambiar modo global
+  useEffect(() => {
+    setPage(1);
+  }, [platformMode]);
+
+  const allPositions = data?.positions ?? [];
   const total = data?.total ?? 0;
   const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  // Filtrar posiciones por modo global activo
+  const positions = allPositions.filter((p) => {
+    return p.mode === platformMode;
+  });
 
   // Collect unique symbols from open positions and keep prices fresh
   const openSymbols =

--- a/apps/web/src/pages/dashboard/trade-history.tsx
+++ b/apps/web/src/pages/dashboard/trade-history.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Filter, Eye, X, TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import { useTradeHistory, type Trade } from '../../hooks/use-analytics';
 import { cn } from '../../lib/utils';
 import { useTranslation } from 'react-i18next';
+import { usePlatformMode } from '../../hooks/use-user';
 
-type FilterType = 'ALL' | 'BUY' | 'SELL' | 'LIVE' | 'PAPER';
+type FilterType = 'ALL' | 'BUY' | 'SELL' | 'LIVE' | 'TESTNET' | 'SANDBOX' | 'PAPER';
 
 // ── Trade Detail Modal ───────────────────────────────────────────────────────
 function TradeDetailModal({
@@ -371,15 +372,23 @@ function TradeRow({
 
 export function TradeHistoryPage() {
   const { t } = useTranslation();
-  const [filter, setFilter] = useState<FilterType>('ALL');
+  const { mode: platformMode } = usePlatformMode();
+  const [filter, setFilter] = useState<FilterType>(() => platformMode);
   const [selectedTrade, setSelectedTrade] = useState<Trade | null>(null);
   const { data: trades = [], isLoading } = useTradeHistory(100);
+
+  // Sincronizar filtro con el modo global cuando cambia
+  useEffect(() => {
+    setFilter(platformMode);
+  }, [platformMode]);
 
   const filtered = trades.filter((tr) => {
     if (filter === 'ALL') return true;
     if (filter === 'BUY') return tr.type === 'BUY';
     if (filter === 'SELL') return tr.type === 'SELL';
     if (filter === 'LIVE') return tr.mode === 'LIVE';
+    if (filter === 'TESTNET') return tr.mode === 'TESTNET';
+    if (filter === 'SANDBOX') return tr.mode === 'SANDBOX' || tr.mode === 'PAPER';
     if (filter === 'PAPER') return tr.mode === 'PAPER';
     return true;
   });
@@ -388,8 +397,9 @@ export function TradeHistoryPage() {
     { value: 'ALL', label: t('tradeHistory.all') },
     { value: 'BUY', label: t('tradeHistory.buys') },
     { value: 'SELL', label: t('tradeHistory.sells') },
+    { value: 'SANDBOX', label: 'Sandbox' },
+    { value: 'TESTNET', label: 'Testnet' },
     { value: 'LIVE', label: t('tradeHistory.live') },
-    { value: 'PAPER', label: t('tradeHistory.paper') },
   ];
 
   const COLUMNS = [

--- a/apps/web/src/pages/dashboard/trade-history.tsx
+++ b/apps/web/src/pages/dashboard/trade-history.tsx
@@ -5,7 +5,14 @@ import { cn } from '../../lib/utils';
 import { useTranslation } from 'react-i18next';
 import { usePlatformMode } from '../../hooks/use-user';
 
-type FilterType = 'ALL' | 'BUY' | 'SELL' | 'LIVE' | 'TESTNET' | 'SANDBOX' | 'PAPER';
+type FilterType =
+  | 'ALL'
+  | 'BUY'
+  | 'SELL'
+  | 'LIVE'
+  | 'TESTNET'
+  | 'SANDBOX'
+  | 'PAPER';
 
 // ── Trade Detail Modal ───────────────────────────────────────────────────────
 function TradeDetailModal({
@@ -388,7 +395,8 @@ export function TradeHistoryPage() {
     if (filter === 'SELL') return tr.type === 'SELL';
     if (filter === 'LIVE') return tr.mode === 'LIVE';
     if (filter === 'TESTNET') return tr.mode === 'TESTNET';
-    if (filter === 'SANDBOX') return tr.mode === 'SANDBOX' || tr.mode === 'PAPER';
+    if (filter === 'SANDBOX')
+      return tr.mode === 'SANDBOX' || tr.mode === 'PAPER';
     if (filter === 'PAPER') return tr.mode === 'PAPER';
     return true;
   });

--- a/docs/plans/32-operation-mode-selector.md
+++ b/docs/plans/32-operation-mode-selector.md
@@ -1,0 +1,391 @@
+# Plan 32 — Selector Global de Modo de Operación
+
+**Spec:** [32-operation-mode-selector.md](../specs/branches/32-operation-mode-selector.md)  
+**Branch:** `feature/32-operation-mode-selector`  
+**Prioridad:** 🔴 CRÍTICA  
+**Fecha:** 2026-04-13
+
+---
+
+## Estado inicial requerido
+
+Antes de empezar la implementación, verificar:
+
+```bash
+# Branch base
+git checkout main && git pull
+git checkout -b feature/32-operation-mode-selector
+
+# Estado de migraciones aplicadas
+pnpm nx run api:prisma-migrate-status
+
+# Verificar que spec 20 (testnet) está implementada
+grep -r "useTestnetBinanceKeyStatus" apps/web/src/hooks/use-user.ts
+```
+
+---
+
+## Fase A — Backend: modelo + endpoint
+
+**Estimado:** ~2-3 horas  
+**Criterio de cierre:** Tests unitarios pasan, endpoint PATCH funciona con validación
+
+### A1 — Migración Prisma
+
+**Archivo:** `apps/api/prisma/schema.prisma`
+
+Agregar en el modelo `User`:
+
+```prisma
+platformOperationMode  TradingMode  @default(SANDBOX)
+```
+
+Generar y aplicar migración:
+
+```bash
+pnpm nx run api:prisma-migrate -- --name add_platform_operation_mode
+```
+
+### A2 — DTO de actualización
+
+**Archivo nuevo:** `apps/api/src/users/dto/update-operation-mode.dto.ts`
+
+```typescript
+import { IsEnum } from 'class-validator';
+import { TradingMode } from '../../../generated/prisma';
+
+export class UpdateOperationModeDto {
+  @IsEnum(TradingMode)
+  mode: TradingMode;
+}
+```
+
+### A3 — Servicio: método updateOperationMode
+
+**Archivo:** `apps/api/src/users/users.service.ts`
+
+Agregar método `updateOperationMode(userId: string, mode: TradingMode)`:
+
+- Si `mode === LIVE`: verificar que existe `BinanceCredential` con `userId` y `isTestnet: false` → lanzar `BadRequestException` si no.
+- Si `mode === TESTNET`: verificar que existe `BinanceCredential` con `userId` y `isTestnet: true` → lanzar `BadRequestException` si no.
+- Si `mode === SANDBOX`: siempre permitido.
+- Actualizar `User.platformOperationMode` con el nuevo mode.
+
+Asegurar que `getProfile(userId)` incluye `platformOperationMode` en el objeto retornado.
+
+### A4 — Controlador: endpoint PATCH
+
+**Archivo:** `apps/api/src/users/users.controller.ts`
+
+```typescript
+@Patch('me/operation-mode')
+@UseGuards(JwtAuthGuard)
+async updateOperationMode(
+  @CurrentUser() user: User,
+  @Body() dto: UpdateOperationModeDto,
+) {
+  return this.usersService.updateOperationMode(user.id, dto.mode);
+}
+```
+
+### A5 — Mock actualizado
+
+**Archivo:** `apps/api/src/__mocks__/generated-prisma.ts`
+
+Agregar `platformOperationMode: 'SANDBOX'` en el objeto User mockeado.
+
+### A6 — Tests unitarios
+
+**Archivo:** `apps/api/src/users/users.service.spec.ts` (o nuevo spec file si no existe)
+
+Casos a cubrir:
+
+- `updateOperationMode(userId, SANDBOX)` → siempre ok, actualiza el campo
+- `updateOperationMode(userId, LIVE)` cuando no hay keys → BadRequestException
+- `updateOperationMode(userId, TESTNET)` cuando no hay keys → BadRequestException
+- `updateOperationMode(userId, LIVE)` cuando SÍ hay keys → actualiza ok
+- `getProfile(userId)` incluye `platformOperationMode` en la respuesta
+
+### Checkpoints Fase A
+
+```bash
+pnpm nx run api:build          # Build sin errores
+pnpm nx run api:test           # Tests pasan
+pnpm nx run api:prisma-migrate-status  # Migración aplicada
+```
+
+---
+
+## Fase B — Frontend: hook + componente ModeSelector
+
+**Estimado:** ~3-4 horas  
+**Criterio de cierre:** El ModeSelector aparece y funciona en el DashboardHeader
+
+### B1 — Hooks en use-user.ts
+
+**Archivo:** `apps/web/src/hooks/use-user.ts`
+
+Agregar:
+
+```typescript
+// Hook para leer el modo activo del perfil
+export function usePlatformMode() {
+  const { data: profile, isLoading } = useUserProfile();
+  const { data: liveKeyStatus } = useBinanceKeyStatus();
+  const { data: testnetKeyStatus } = useTestnetBinanceKeyStatus();
+
+  const mode = profile?.platformOperationMode ?? 'SANDBOX';
+  const availableModes: TradingMode[] = ['SANDBOX'];
+  if (testnetKeyStatus?.hasKey) availableModes.push('TESTNET');
+  if (liveKeyStatus?.hasKey) availableModes.push('LIVE');
+
+  return {
+    mode,
+    isSandbox: mode === 'SANDBOX',
+    isTestnet: mode === 'TESTNET',
+    isLive: mode === 'LIVE',
+    availableModes,
+    isLoading,
+  };
+}
+
+// Hook para actualizar el modo
+export function useUpdatePlatformMode() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (mode: TradingMode) =>
+      api.patch('/users/me/operation-mode', { mode }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-profile'] });
+    },
+  });
+}
+```
+
+### B2 — Componente ModeSelector
+
+**Archivo nuevo:** `apps/web/src/components/mode-selector.tsx`
+
+Comportamiento:
+
+- Badge pill en el header con el modo activo: color ámbar (SANDBOX), naranja (TESTNET), verde con pulse (LIVE)
+- Click → dropdown con los 3 modos
+- Modos sin keys: texto gris + tooltip "Configura claves en Settings"
+- Modos disponibles: clickeables
+- Al seleccionar LIVE: mostrar `ConfirmDialog` antes de persistir
+- Optimistic update: badge cambia inmediatamente, si falla → rollback + toast error
+- Iconos: FlaskConical (SANDBOX), TestTube (TESTNET), Activity (LIVE)
+
+### B3 — Integrar en DashboardHeader
+
+**Archivo:** `apps/web/src/components/dashboard-header.tsx`
+
+Agregar `<ModeSelector />` entre `<ConnectionStatusDropdown />` y el botón de notificaciones:
+
+```tsx
+{
+  /* Mode selector */
+}
+<ModeSelector />;
+
+{
+  /* Notifications bell */
+}
+```
+
+### Checkpoints Fase B
+
+```bash
+pnpm nx run web:build          # Build sin errores TS
+pnpm nx run web:lint           # Sin errores de lint
+# Verificación visual: el ModeSelector aparece en el header
+```
+
+---
+
+## Fase C — Páginas: consumo del modo global
+
+**Estimado:** ~3-4 horas  
+**Criterio de cierre:** Todas las páginas reaccionan al cambio de modo global
+
+### C1 — trade-history.tsx
+
+**Archivo:** `apps/web/src/pages/dashboard/trade-history.tsx`
+
+- Importar `usePlatformMode`
+- Inicializar el filtro de modo con `mode` del hook en lugar de hardcode o estado independiente
+- Usar `useEffect` para resetear filtro cuando `mode` cambia
+- Mantener opción 'ALL' en el selector de filtro
+
+### C2 — positions.tsx
+
+**Archivo:** `apps/web/src/pages/dashboard/positions.tsx`
+
+- Importar `usePlatformMode`
+- Inicializar el filtro de modo con `mode`
+- Resetear filtro cuando `mode` cambia
+- Agregar badge del modo activo en la sección de header de la página
+
+### C3 — agent-log.tsx
+
+**Archivo:** `apps/web/src/pages/dashboard/agent-log.tsx`
+
+- Importar `usePlatformMode`
+- Inicializar el filtro de modo con `mode`
+- Resetear filtro cuando `mode` cambia
+
+### C4 — config.tsx
+
+**Archivo:** `apps/web/src/pages/dashboard/config.tsx`
+
+- Importar `usePlatformMode`
+- Al abrir el formulario de nueva TradingConfig, pre-seleccionar `mode` del modo global activo como valor por defecto del campo `mode` del formulario
+- Si el formulario tiene `mode === 'LIVE'` pero el modo global es `SANDBOX`: mostrar warning "Estás creando una configuración LIVE pero el modo global es SANDBOX"
+
+### C5 — bot-analysis.tsx
+
+**Archivo:** `apps/web/src/pages/dashboard/bot-analysis.tsx`
+
+- Importar `usePlatformMode`
+- Usar `mode` como filtro inicial por defecto
+- Resetear filtro cuando `mode` cambia
+
+### C6 — overview.tsx
+
+**Archivo:** `apps/web/src/pages/dashboard/overview.tsx`
+
+- Importar `usePlatformMode`
+- Mostrar badge del modo activo junto al nombre del usuario o en la sección de stats
+- El widget de balance usa el hook adecuado según `mode` (SANDBOX → sandboxWallet, TESTNET/LIVE → binanceBalance)
+
+### Checkpoints Fase C
+
+```bash
+pnpm nx run web:build
+pnpm nx run web:lint
+# Verificación manual: cambiar modo en header → páginas reaccionan
+```
+
+---
+
+## Fase D — Fallback seguridad + i18n + E2E
+
+**Estimado:** ~2-3 horas  
+**Criterio de cierre:** Tests E2E pasan, fallback funciona, i18n completo
+
+### D1 — Fallback en frontend
+
+**Archivo:** `apps/web/src/hooks/use-user.ts`
+
+En `usePlatformMode()`, detectar si el modo almacenado no está en `availableModes`:
+
+```typescript
+// Si el modo activo ya no tiene keys, hacer fallback a SANDBOX
+useEffect(() => {
+  if (!isLoading && mode !== 'SANDBOX' && !availableModes.includes(mode)) {
+    updateMode.mutate('SANDBOX');
+    toast.warning(t('modeSelector.fallbackNotice', { mode }));
+  }
+}, [mode, availableModes, isLoading]);
+```
+
+### D2 — i18n
+
+**Archivos:** `apps/web/src/locales/es.ts` y `apps/web/src/locales/en.ts`
+
+Agregar bajo la sección `modeSelector`:
+
+```typescript
+// es.ts
+modeSelector: {
+  label: 'Modo de operación',
+  sandbox: 'Sandbox',
+  testnet: 'Testnet',
+  live: 'En Vivo',
+  sandboxDesc: 'Simulación con fondos virtuales. Sin riesgo real.',
+  testnetDesc: 'Órdenes reales en red de prueba de Binance. Sin dinero real.',
+  liveDesc: '⚠️ Dinero real. Órdenes reales en Binance.',
+  noKeysTooltip: 'Configura tus claves API en Ajustes para habilitar este modo.',
+  switchConfirmTitle: 'Cambiar a modo {{mode}}',
+  switchConfirmDesc: 'Estás a punto de cambiar al modo EN VIVO. Las operaciones afectarán fondos reales en Binance.',
+  switchedSuccess: 'Modo cambiado a {{mode}}',
+  fallbackNotice: 'Modo {{mode}} no disponible. Cambiado a Sandbox automáticamente.',
+}
+```
+
+### D3 — Test E2E
+
+**Archivo nuevo:** `e2e/mode-selector.spec.ts`
+
+Escenarios a cubrir:
+
+- Usuario SANDBOX: solo ve modo SANDBOX habilitado, los otros grayed
+- Usuario con testnet keys: ve SANDBOX + TESTNET habilitados
+- Usuario con live keys: ve todos habilitados
+- Cambio de modo: selector cambia → badge del header actualiza → trade-history filtra por nuevo modo
+- Cambio a LIVE: dialog de confirmación aparece → confirmar → modo cambia
+- Cambio a LIVE: dialog de confirmación → cancelar → modo no cambia
+
+### Checkpoints Fase D
+
+```bash
+pnpm nx run web:build
+pnpm nx run web:lint
+pnpm nx e2e web-e2e --spec=e2e/mode-selector.spec.ts
+```
+
+---
+
+## Criterios de aceptación globales
+
+- [ ] `User.platformOperationMode` existe en DB con default SANDBOX
+- [ ] `PATCH /users/me/operation-mode` valida disponibilidad del modo (keys requeridas)
+- [ ] `GET /users/me/profile` incluye `platformOperationMode`
+- [ ] El `ModeSelector` aparece en el DashboardHeader, visible en todas las páginas del dashboard
+- [ ] Solo se muestran como activos los modos que el usuario tiene configurados
+- [ ] La selección persiste entre sesiones (guardada en DB)
+- [ ] Al cambiar el modo, trade-history, positions y agent-log actualizan su filtro por defecto
+- [ ] La config de trading pre-selecciona el modo global al crear
+- [ ] El cambio a LIVE requiere confirmación explícita
+- [ ] El fallback automático a SANDBOX funciona cuando se eliminan keys
+- [ ] i18n completo en ES y EN
+- [ ] Tests E2E del flujo completo pasan
+
+---
+
+## Cierre de branch
+
+```bash
+# Verificación final
+pnpm nx run api:build
+pnpm nx run api:test
+pnpm nx run web:build
+pnpm nx run web:lint
+pnpm nx e2e web-e2e --spec=e2e/mode-selector.spec.ts
+
+# PR
+gh pr create \
+  --base main \
+  --head feature/32-operation-mode-selector \
+  --title "feat(32): selector global de modo de operación (SANDBOX/TESTNET/LIVE)" \
+  --body "## Resumen
+
+Implementa el selector global de modo de operación en el DashboardHeader.
+
+## Cambios principales
+- Campo \`platformOperationMode\` en modelo User (Prisma)
+- Endpoint \`PATCH /users/me/operation-mode\` con validación de keys
+- Componente \`ModeSelector\` en DashboardHeader
+- Hook \`usePlatformMode()\` consumido por todas las páginas del dashboard
+- Filtros de trade-history, positions, agent-log, bot-analysis sincronizados con modo global
+- Confirmación obligatoria al cambiar a modo LIVE
+- Fallback automático a SANDBOX si keys son eliminadas
+- i18n ES + EN completo
+- Tests E2E del flujo completo
+
+## Spec
+docs/specs/branches/32-operation-mode-selector.md
+
+## Screenshots
+[adjuntar screenshots del ModeSelector en acción]"
+```

--- a/docs/plans/crypto-trader-branch-plan.md
+++ b/docs/plans/crypto-trader-branch-plan.md
@@ -2,25 +2,26 @@
 
 ## Estructura de branches y specs
 
-| #   | Branch                         | Spec file                    | Depende de |
-| --- | ------------------------------ | ---------------------------- | ---------- |
-| 01  | feature/foundation             | 01-foundation.md             | —          |
-| 02  | feature/auth-users             | 02-auth-users.md             | 01         |
-| 03  | feature/data-layer             | 03-data-layer.md             | 01         |
-| 04  | feature/analysis-engine        | 04-analysis-engine.md        | 01         |
-| 05  | feature/trading-engine         | 05-trading-engine.md         | 02,03,04   |
-| 06  | feature/backend-support        | 06-backend-support.md        | 05         |
-| 07  | feature/frontend-foundation    | 07-frontend-foundation.md    | 01         |
-| 08  | feature/frontend-auth          | 08-frontend-auth.md          | 02,07      |
-| 09  | feature/frontend-dashboard     | 09-frontend-dashboard.md     | 07         |
-| 10  | feature/frontend-features      | 10-frontend-features.md      | 09         |
-| 11  | feature/frontend-integration   | 11-frontend-integration.md   | 10,06      |
-| 12  | feature/devops                 | 12-devops.md                 | 11         |
-| 13  | feature/e2e-tests              | 13-e2e-tests.md              | 12         |
-| 28  | feature/multi-agent-chat-rag   | 28-multi-agent-chat-rag.md   | 17         |
-| 29  | feature/adaptive-agents        | 29-adaptive-agents.md        | 28         |
-| 30  | feature/multi-agent-e2e-qa     | 30-multi-agent-e2e-qa.md     | 28         |
-| 31  | feature/llm-provider-dashboard | 31-llm-provider-dashboard.md | 23,17      |
+| #   | Branch                             | Spec file                     | Depende de |
+| --- | ---------------------------------- | ----------------------------- | ---------- |
+| 01  | feature/foundation                 | 01-foundation.md              | —          |
+| 02  | feature/auth-users                 | 02-auth-users.md              | 01         |
+| 03  | feature/data-layer                 | 03-data-layer.md              | 01         |
+| 04  | feature/analysis-engine            | 04-analysis-engine.md         | 01         |
+| 05  | feature/trading-engine             | 05-trading-engine.md          | 02,03,04   |
+| 06  | feature/backend-support            | 06-backend-support.md         | 05         |
+| 07  | feature/frontend-foundation        | 07-frontend-foundation.md     | 01         |
+| 08  | feature/frontend-auth              | 08-frontend-auth.md           | 02,07      |
+| 09  | feature/frontend-dashboard         | 09-frontend-dashboard.md      | 07         |
+| 10  | feature/frontend-features          | 10-frontend-features.md       | 09         |
+| 11  | feature/frontend-integration       | 11-frontend-integration.md    | 10,06      |
+| 12  | feature/devops                     | 12-devops.md                  | 11         |
+| 13  | feature/e2e-tests                  | 13-e2e-tests.md               | 12         |
+| 28  | feature/multi-agent-chat-rag       | 28-multi-agent-chat-rag.md    | 17         |
+| 29  | feature/adaptive-agents            | 29-adaptive-agents.md         | 28         |
+| 30  | feature/multi-agent-e2e-qa         | 30-multi-agent-e2e-qa.md      | 28         |
+| 31  | feature/llm-provider-dashboard     | 31-llm-provider-dashboard.md  | 23,17      |
+| 32  | feature/32-operation-mode-selector | 32-operation-mode-selector.md | 20,02,09   |
 
 ## Flujo recomendado
 

--- a/docs/specs/branches/32-operation-mode-selector.md
+++ b/docs/specs/branches/32-operation-mode-selector.md
@@ -1,0 +1,321 @@
+# Spec 32 — Selector Global de Modo de Operación
+
+**Branch:** `feature/32-operation-mode-selector`  
+**Prioridad:** 🔴 CRÍTICA  
+**Estado:** Pendiente  
+**Fecha:** 2026-04-13
+
+---
+
+## Resumen ejecutivo
+
+La plataforma mezcla actualmente datos y comportamientos de los tres modos de operación (SANDBOX, TESTNET, LIVE) en las mismas vistas, sin una separación clara de contexto. El usuario no tiene un control centralizado para definir en qué modo está operando globalmente, lo que genera confusión, datos entremezclados y riesgo de ejecutar acciones en el modo incorrecto.
+
+Esta spec introduce un **Selector Global de Modo de Operación** en el `DashboardHeader`, que determina el contexto activo de toda la plataforma. La selección es persistente por usuario en el backend. Solo se muestran los modos que el usuario tiene configurados (con claves API disponibles o modo sandbox siempre disponible). Todas las páginas del dashboard que presentan datos scoped por modo deben respetar y reaccionar a este selector.
+
+---
+
+## Problema actual
+
+1. **Mezcla de datos**: Las páginas de `trade-history`, `positions`, `agent-log` muestran datos de todos los modos mezclados, con filtros secundarios por modo pero sin un contexto global activo.
+2. **Sin persistencia**: No existe concepto de "modo de operación activo del usuario" a nivel de sesión/perfil. Cada página decide su propio estado de filtro.
+3. **Riesgo operativo**: Un usuario podría creer que está operando en SANDBOX cuando realmente su configuración activa es LIVE.
+4. **Onboarding incompleto**: El modo elegido en onboarding se aplica por TradingConfig pero no existe un "modo global de plataforma".
+
+---
+
+## Arquitectura
+
+### Concepto central: `platformOperationMode`
+
+Se introduce un campo `platformOperationMode: TradingMode` en el modelo `User` de Prisma. Este campo representa el modo de visualización y operación activo de la plataforma para ese usuario.
+
+**Reglas de negocio:**
+
+- SANDBOX siempre está disponible (no requiere keys).
+- TESTNET solo aparece como opción si el usuario tiene `binanceTestnetKey` configurada.
+- LIVE solo aparece si el usuario tiene `binanceKey` (producción) configurada.
+- El modo activo se persiste en DB y se devuelve en el perfil del usuario.
+- Al cambiar de modo, la UI actualiza todas las páginas afectadas sin navegación.
+- Si el modo activo almacenado se vuelve inválido (ej: el usuario borra sus keys de LIVE), el sistema hace fallback a SANDBOX y notifica al usuario.
+
+### Flujo de datos
+
+```
+DashboardHeader
+  └─ ModeSelector (nuevo componente)
+       ├─ Lee: useUserProfile() → platformOperationMode
+       ├─ Lee: useBinanceKeyStatus() → hasLiveKeys
+       ├─ Lee: useTestnetBinanceKeyStatus() → hasTestnetKeys
+       ├─ Calcula: availableModes = ['SANDBOX', + TESTNET si hasTestnetKeys, + LIVE si hasLiveKeys]
+       ├─ Muestra: Solo los modos disponibles
+       └─ Al cambiar: PATCH /users/me/operation-mode → invalida query de perfil
+
+usePlatformMode() (nuevo hook)
+  └─ Lee el platformOperationMode del perfil del usuario
+  └─ Consumido por todas las páginas para filtrar/contextualizar datos
+```
+
+---
+
+## Modelos de datos
+
+### Prisma — User model
+
+```prisma
+model User {
+  // ... campos existentes ...
+  platformOperationMode  TradingMode  @default(SANDBOX)
+}
+```
+
+### Nueva migración
+
+```
+apps/api/prisma/migrations/YYYYMMDD_HHMMSS_add_platform_operation_mode/migration.sql
+```
+
+```sql
+ALTER TABLE "User" ADD COLUMN "platformOperationMode" "TradingMode" NOT NULL DEFAULT 'SANDBOX';
+```
+
+---
+
+## API Endpoints
+
+### Nuevo endpoint
+
+| Método  | Path                       | Descripción                                                         |
+| ------- | -------------------------- | ------------------------------------------------------------------- |
+| `PATCH` | `/users/me/operation-mode` | Actualiza el modo de operación activo del usuario                   |
+| `GET`   | `/users/me/profile`        | Ya existente — debe incluir `platformOperationMode` en la respuesta |
+
+### DTO `UpdateOperationModeDto`
+
+```typescript
+export class UpdateOperationModeDto {
+  @IsEnum(TradingMode)
+  mode: TradingMode;
+}
+```
+
+### Validaciones server-side
+
+- Si `mode === 'LIVE'` y el usuario no tiene `binanceKey` → `400 Bad Request` con mensaje `"No Binance production keys configured"`.
+- Si `mode === 'TESTNET'` y el usuario no tiene `binanceTestnetKey` → `400 Bad Request` con mensaje `"No Binance testnet keys configured"`.
+- Si `mode === 'SANDBOX'` → siempre permitido.
+
+---
+
+## Fases de implementación
+
+### Fase A — Backend: modelo + endpoint
+
+**Archivos comprometidos:**
+
+- `apps/api/prisma/schema.prisma` — agregar `platformOperationMode TradingMode @default(SANDBOX)` al modelo `User`
+- `apps/api/prisma/migrations/` — nueva migración SQL
+- `apps/api/src/users/dto/update-operation-mode.dto.ts` — nuevo DTO con validación
+- `apps/api/src/users/users.service.ts` — método `updateOperationMode(userId, mode)` con validaciones de keys
+- `apps/api/src/users/users.controller.ts` — endpoint `PATCH /users/me/operation-mode`
+- `apps/api/src/users/users.service.ts` — asegurar que `getProfile()` incluye `platformOperationMode`
+- `apps/api/src/__mocks__/generated-prisma.ts` — agregar `platformOperationMode` al mock User
+
+**Criterios Fase A:**
+
+- Migración aplicable y reversible
+- El endpoint `PATCH /users/me/operation-mode` valida modos y keys
+- El perfil del usuario incluye `platformOperationMode`
+- Tests unitarios del servicio con casos: SANDBOX ok, LIVE sin keys → 400, TESTNET sin keys → 400
+
+---
+
+### Fase B — Frontend: hook + componente ModeSelector
+
+**Archivos comprometidos:**
+
+- `apps/web/src/hooks/use-user.ts` — agregar hook `usePlatformMode()` y `useUpdatePlatformMode()`
+- `apps/web/src/components/mode-selector.tsx` — nuevo componente selector de modo
+- `apps/web/src/components/dashboard-header.tsx` — integrar `<ModeSelector />`
+
+**Detalles del componente `ModeSelector`:**
+
+```tsx
+// Comportamiento
+- Badge/pill visible en el header con el modo activo: [🟡 SANDBOX] [🟠 TESTNET] [🔴 LIVE]
+- Al hacer click: dropdown que SIEMPRE muestra las 3 opciones (SANDBOX, TESTNET, LIVE)
+- Modos NO configurados: aparecen visualmente apagados (opacity reducida + ícono de candado)
+  → Al hacer click sobre ellos: se abre el modal "CredentialsRequiredModal" (ver abajo)
+  → NO se seleccionan como modo activo
+- Modos configurados: clickeables y seleccionables normalmente
+- Al seleccionar un modo disponible: llama useUpdatePlatformMode() → optimistic update → persiste en backend
+- Loading state: badge con spinner mientras persiste
+- Error state: rollback al modo anterior + toast de error
+- Visual:
+  - SANDBOX: badge amarillo/ámbar — ícono FlaskConical
+  - TESTNET: badge naranja — ícono TestTube
+  - LIVE: badge verde/rojo pulsante — ícono Activity (indica dinero real)
+  - No configurado: item con opacity-50 + ícono Lock a la derecha
+```
+
+**Modal `CredentialsRequiredModal`:**
+
+```tsx
+// Se muestra cuando el usuario toca un modo no configurado
+// Props: mode: TradingMode, onClose: () => void
+
+Título: "Modo {{mode}} no configurado"
+
+Contenido según modo:
+  - TESTNET: "Para operar en modo Testnet necesitás configurar tus claves API de Binance Testnet.
+               Obtenelas gratis en testnet.binance.vision (sin dinero real)."
+  - LIVE:     "Para operar en modo En Vivo necesitás configurar tus claves API de Binance.
+               ⚠️ Este modo opera con fondos reales."
+
+Botones:
+  1. "Cancelar" (ghost/secondary) → cierra el modal
+  2. "Agregar Credenciales" (primary) → navega a /dashboard/settings con el tab correcto pre-seleccionado:
+       - TESTNET → abre Settings en la sección "Claves Binance Testnet"
+       - LIVE    → abre Settings en la sección "Claves Binance"
+
+El modal cierra el dropdown automáticamente al abrirse.
+```
+
+**Hook `usePlatformMode()`:**
+
+```typescript
+// Retorna:
+{
+  mode: TradingMode;             // modo activo (del perfil)
+  isSandbox: boolean;
+  isTestnet: boolean;
+  isLive: boolean;
+  availableModes: TradingMode[];  // modos con keys configuradas
+  isLoading: boolean;
+}
+```
+
+**Criterios Fase B:**
+
+- El ModeSelector aparece en el DashboardHeader entre la conexión y las notificaciones
+- Siempre muestra las 3 opciones (SANDBOX, TESTNET, LIVE) en el dropdown, sin excepción
+- Modos no configurados: visualmente apagados (opacity-50 + ícono Lock), no cambian el modo activo al tocarse
+- Al tocar un modo no configurado: se abre el modal `CredentialsRequiredModal` (no el dropdown cierra solo)
+- El modal muestra descripción contextual del modo y tiene botones "Cancelar" y "Agregar Credenciales"
+- "Agregar Credenciales" navega a Settings con el tab correcto pre-seleccionado y cierra el modal
+- La selección de un modo disponible persiste correctamente en el backend
+- Optimistic update + manejo de error con rollback
+
+---
+
+### Fase C — Páginas: consumo del modo global
+
+Todas las páginas listadas abajo deben importar `usePlatformMode()` y usar `mode` como filtro/contexto inicial por defecto, en lugar de estado local independiente.
+
+**Archivos comprometidos:**
+
+#### `apps/web/src/pages/dashboard/overview.tsx`
+
+- Mostrar badge del modo activo en la sección de stats de resumen
+- Widget de balance: mostrar balance correspondiente al modo activo (sandbox wallet / binance testnet / binance live) — ya implementado en spec 20, conectar con modo global
+
+#### `apps/web/src/pages/dashboard/trade-history.tsx`
+
+- Inicializar el filtro de modo con `usePlatformMode().mode` en lugar de 'ALL'
+- Cuando el modo global cambia → resetear el filtro al nuevo modo activo
+- Mantener la posibilidad de ver 'ALL' como opción adicional
+
+#### `apps/web/src/pages/dashboard/positions.tsx`
+
+- Inicializar el filtro de modo con `usePlatformMode().mode`
+- Cuando el modo global cambia → resetear filtro
+- Badge de modo activo visible en la cabecera de la página
+
+#### `apps/web/src/pages/dashboard/agent-log.tsx`
+
+- Inicializar el filtro de modo con `usePlatformMode().mode`
+- Cuando el modo global cambia → resetear filtro
+
+#### `apps/web/src/pages/dashboard/config.tsx`
+
+- Al crear una nueva TradingConfig: pre-seleccionar el modo global activo como valor por defecto del campo `mode`
+- Warning visual si el usuario crea una config LIVE pero el modo global es SANDBOX
+- Mostrar badge del modo activo en el header de la página
+
+#### `apps/web/src/pages/dashboard/bot-analysis.tsx`
+
+- Filtrar análisis del bot por modo global por defecto
+- Resetear al cambiar modo global
+
+#### `apps/web/src/pages/dashboard/overview.tsx`
+
+- En el widget de "Configuraciones activas": diferenciar por modo activo
+
+**Criterios Fase C:**
+
+- Todas las páginas usan el modo global como filtro inicial
+- Al cambiar el modo en el header, las páginas reaccionan inmediatamente (sin navegación)
+- La experiencia indica claramente en qué "entorno" se está operando
+
+---
+
+### Fase D — Fallback de seguridad + i18n
+
+**Archivos comprometidos:**
+
+- `apps/api/src/users/users.service.ts` — lógica de fallback: si el modo almacenado ya no es válido (keys eliminadas), hacer fallback a SANDBOX
+- `apps/web/src/hooks/use-user.ts` — detectar incoherencia y disparar `useUpdatePlatformMode('SANDBOX')` + toast
+- `apps/web/src/locales/es.ts` — claves i18n para labels, tooltips, confirmaciones del ModeSelector
+- `apps/web/src/locales/en.ts` — ídem inglés
+- `e2e/mode-selector.spec.ts` — tests E2E del flujo completo
+
+**Claves i18n mínimas:**
+
+```typescript
+// es.ts
+modeSelector: {
+  label: 'Modo de operación',
+  sandbox: 'Sandbox',
+  testnet: 'Testnet',
+  live: 'En Vivo',
+  sandboxDesc: 'Simulación con fondos virtuales. Sin riesgo real.',
+  testnetDesc: 'Órdenes reales en red de prueba de Binance. Sin dinero real.',
+  liveDesc: '⚠️ Dinero real. Órdenes reales en Binance.',
+  switchConfirmTitle: 'Cambiar a modo En Vivo',
+  switchConfirmDesc: 'Estás a punto de cambiar al modo EN VIVO. Las operaciones afectarán fondos reales en Binance.',
+  switchedSuccess: 'Modo cambiado a {{mode}}',
+  fallbackNotice: 'Modo {{mode}} no disponible. Cambiado a Sandbox automáticamente.',
+  // Modal credenciales
+  credentialsModalTitle: 'Modo {{mode}} no configurado',
+  credentialsModalTestnetDesc: 'Para operar en modo Testnet necesitás configurar tus claves API de Binance Testnet. Obtenelas gratis en testnet.binance.vision (sin dinero real).',
+  credentialsModalLiveDesc: 'Para operar en modo En Vivo necesitás configurar tus claves API de Binance. ⚠️ Este modo opera con fondos reales.',
+  credentialsModalCancel: 'Cancelar',
+  credentialsModalCta: 'Agregar Credenciales',
+}
+```
+
+---
+
+## Out of Scope
+
+- Cambio de UX del onboarding (ya tiene selección de modo por TradingConfig).
+- Refactor de las TradingConfigs para que hereden el modo global automáticamente.
+- Implementación del balance widget para LIVE/TESTNET (ya cubierto en Spec 20).
+- Restricción de creación de TradingConfigs según el modo global (puede ser una mejora futura).
+- Notificaciones push al cambiar de modo.
+
+---
+
+## Decisiones de diseño
+
+| Decisión                                                                  | Alternativa considerada                   | Motivo                                                                                                                                                              |
+| ------------------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Campo `platformOperationMode` en `User` vs estado solo en frontend        | Solo estado frontend (Zustand)            | La persistencia en DB garantiza consistencia entre sesiones y dispositivos. El estado frontend puede derivarse del perfil.                                          |
+| Fallback automático a SANDBOX                                             | Bloquear el acceso si el modo es inválido | UX menos disruptiva. El usuario siempre puede operar en Sandbox.                                                                                                    |
+| Siempre mostrar los 3 modos; no configurados abren modal de configuración | Ocultar modos no disponibles              | El usuario ve todas sus opciones posibles y entiende qué necesita para habilitarlas. El modal guía la acción directamente hacia Settings en lugar de solo informar. |
+| Confirmación dialog para cambio a LIVE                                    | Sin confirmación                          | El modo LIVE involucra dinero real → el usuario debe ser consciente del cambio.                                                                                     |
+
+---
+
+**Depende de:** 20 (Testnet Support), 02 (Auth/Users), 09 (Frontend Dashboard)  
+**Siguiente:** Sin asignación aún


### PR DESCRIPTION
## Resumen

Introduce un **Selector Global de Modo de Operación** (SANDBOX / TESTNET / LIVE) en el `DashboardHeader`, persistido por usuario en el backend. Todas las páginas del dashboard respetan el modo seleccionado.

## Problema resuelto

- La plataforma mezclaba datos de diferentes modos en las mismas vistas
- No existía un "modo activo global" persistente — cada página manejaba su propio filtro
- Riesgo operativo: el usuario podía confundir en qué modo estaba operando

## Cambios

### Backend (Fase A)
- Nuevo campo `platformOperationMode` en modelo `User` (Prisma) con default `SANDBOX`
- Enum `OperationMode` (`SANDBOX` | `TESTNET` | `LIVE`)
- Endpoint `PATCH /users/me/operation-mode` para actualizar el modo
- Migración Prisma incluida
- Tests unitarios para el servicio

### Frontend — Componente ModeSelector (Fase B)
- Componente `ModeSelector` con indicador visual por modo (colores, iconos)
- Hook `usePlatformMode()` con TanStack Query + mutación optimista
- Integrado en `DashboardHeader`
- i18n completo (EN/ES)

### Frontend — Sync de páginas (Fase C)
- `trade-history`, `positions`, `agent-log`, `config` ahora sincronizan su filtro de modo con el selector global
- Cambiar el modo global actualiza automáticamente los datos en todas las páginas

### Frontend — Fallback automático (Fase D)
- Fallback a SANDBOX si el modo actual no tiene keys configuradas
- Solo muestra modos disponibles según las API keys del usuario

## Archivos modificados

19 archivos, +1483 / -42 líneas

| Área | Archivos clave |
|------|---------------|
| Prisma | `schema.prisma`, migración SQL |
| API | `users.controller.ts`, `users.service.ts`, `auth.dto.ts` |
| Frontend | `mode-selector.tsx`, `use-user.ts`, `dashboard-header.tsx` |
| Páginas | `agent-log.tsx`, `config.tsx`, `positions.tsx`, `trade-history.tsx` |
| i18n | `en.ts`, `es.ts` |
| Docs | Spec 32 + Plan 32 + branch plan actualizado |

## Testing

- ✅ API build exitoso
- ✅ Web build exitoso
- ✅ Tests unitarios de `UsersService` pasando
- ✅ Análisis lib tests pasando (34/34)

## Spec & Plan

- `docs/specs/branches/32-operation-mode-selector.md`
- `docs/plans/32-operation-mode-selector.md`