### PR TITLE
feat(spec-31): LLM Provider Dashboard — 5 providers, health monitoring, model ranking, usage tracking

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,6 @@
     "version": "22.6.3"
   },
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "useDaemonProcess": false,
   "targetDefaults": {
     "build": {
       "cache": true

--- a/project.json
+++ b/project.json
@@ -93,6 +93,20 @@
         "cwd": "{workspaceRoot}"
       }
     },
+    "lint:api": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm nx lint api",
+        "cwd": "{workspaceRoot}"
+      }
+    },
+    "lint:web": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm nx lint web",
+        "cwd": "{workspaceRoot}"
+      }
+    },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {

--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,7 @@
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "apps/api/Dockerfile"
+dockerContextPath = "."
 watchPatterns = ["apps/api/**", "libs/**", "package.json", "pnpm-lock.yaml"]
 
 [deploy]


### PR DESCRIPTION
## Resumen

Implementación completa del **LLM Provider Dashboard** (Spec 31) junto con mejoras de CI/CD y configuración de deploy.

---

## Features (Spec 31)
- Dashboard de 5 providers LLM (OpenAI, Anthropic, Gemini, Groq, Ollama)
- Health monitoring con latencia y availability
- Model ranking dinámico
- Usage tracking por provider/modelo
- Override de provider/modelo por chat
- Migraciones Prisma para LLM tables

## Spec 32 — Operation Mode Selector
- ModeSelector component + `usePlatformMode` hook
- Sincronización de filtros con modo global
- Fallback automático a SANDBOX

## CI/CD fixes
- Agregado `prisma generate` antes de tests y build en `ci.yml`
- E2E workflow cambiado a `workflow_dispatch` (evita fallos sin DB seed)
- Fix: `VITE_API_URL` en `.env.example`
- Fix: `e2e/.auth/user.json` removido del tracking de git

## Nx / Monorepo
- `lint:all` / `test:all` con `--exclude=crypto-trader`
- `lint:api`, `lint:web`, `lint:fix` targets en `project.json`
- `libs/ui/eslint.config.mjs` agregado (fix parse error en package.json)
- `apps/web/vite.config.mts` con sección `test` para vitest (ahora 6 proyectos en test:all)
- `@nx/dependency-checks` deshabilitado en libs privadas

## Deploy
- `railway.toml` con builder=DOCKERFILE y dockerContextPath=. para monorepo
