### PR TITLE
feat: Toggle global de proveedores LLM + hardening pipeline + OpenRouter dinámico — Spec 38

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # Crypto Trader
 
-Plataforma fullstack de **trading autónomo de criptomonedas** impulsada por un agente de IA híbrida. El agente combina análisis técnico clásico (RSI, MACD, Bollinger Bands, EMA, Volumen, S&R) con razonamiento LLM multi-proveedor (Claude, OpenAI, Groq) para tomar decisiones de compra/venta de BTC y ETH en Binance.
+Plataforma fullstack de **trading autónomo de criptomonedas** impulsada por un agente de IA híbrida. El agente combina análisis técnico clásico (RSI, MACD, Bollinger Bands, EMA, Volumen, S&R) con razonamiento LLM multi-proveedor (OpenRouter, Claude, OpenAI, Groq, Gemini, Mistral, Together) para tomar decisiones de compra/venta de BTC y ETH en Binance.
 
 ---
 
 ## Características principales
 
 - **Agente autónomo** — opera sin intervención manual; detecta oportunidades de BTC/ETH vs USDT/USDC.
-- **IA híbrida** — indicadores técnicos + LLM (Claude / OpenAI / Groq) con claves propias por usuario.
+- **IA híbrida** — indicadores técnicos + LLM multi-proveedor (OpenRouter, Claude, OpenAI, Groq, Gemini, Mistral, Together) con claves propias por usuario.
+- **OpenRouter como hub** — 200+ modelos con una sola API key, catálogo dinámico con cache 15min.
+- **Multi-agente configurable** — cada agente (orchestrator, market, risk, technical, fundamentals, chat) tiene su propio par proveedor/modelo.
+- **Toggle admin de proveedores** — el admin puede activar/desactivar proveedores LLM globalmente; los usuarios afectados reciben notificación.
 - **Multi-usuario aislado** — cada usuario gestiona su propia cuenta Binance, configuraciones y fondos.
 - **Tres modos de operación** — Sandbox (paper trading), Testnet (Binance Testnet) y Live.
 - **Seguro por defecto** — sandbox obligatorio al inicio; live requiere activación explícita.
-- **Transparencia total** — cada decisión del agente se registra con indicadores, razonamiento y noticias.
+- **Transparencia total** — cada decisión del agente se registra con indicadores, razonamiento, proveedor/modelo y noticias.
 - **Dashboard en tiempo real** — gráficos de velas, P&L, posiciones abiertas y log de decisiones via WebSocket.
 - **Internacionalización** — interfaz en Español e Inglés (~1400 claves i18n).
 
@@ -28,7 +31,7 @@ Plataforma fullstack de **trading autónomo de criptomonedas** impulsada por un 
 | ORM / DB | Prisma 7, PostgreSQL 16 |
 | Cache / Colas | Redis 7 |
 | Auth | JWT (15min) + refresh tokens, bcrypt |
-| LLM | Claude (`@anthropic-ai/sdk`), OpenAI, Groq — por usuario |
+| LLM | OpenRouter (`@openrouter/sdk`), Claude, OpenAI, Groq, Gemini, Mistral, Together — por usuario |
 | Trading API | Binance REST + WebSocket |
 | Tests | Vitest (frontend), Jest (backend), Playwright (E2E) |
 | CI/CD | GitHub Actions → GitHub Pages (web) + Railway (api) |
@@ -99,7 +102,7 @@ NODE_ENV=development
 PORT=3000
 ```
 
-> Las claves de LLM (Claude, OpenAI, Groq) y NewsAPI se configuran **por usuario** desde la interfaz — no van en `.env`.
+> Las claves de LLM (OpenRouter, Claude, OpenAI, Groq, Gemini, Mistral, Together) y NewsAPI se configuran **por usuario** desde la interfaz — no van en `.env`.
 
 ---
 
@@ -157,6 +160,7 @@ crypto-trader/
 │   ├── analysis/          Indicadores técnicos + integración LLM
 │   ├── data-fetcher/      Binance OHLCV, noticias (CryptoPanic, RSS)
 │   ├── trading-engine/    Lógica de órdenes y posiciones
+│   ├── openrouter/        Catálogo dinámico de modelos OpenRouter (cache + tipos)
 │   ├── shared/            Types, DTOs, constantes, utils
 │   └── ui/                Componentes React compartidos
 ├── docs/
@@ -177,13 +181,14 @@ Cada N minutos (adaptativo por volatilidad):
 1. Fetch OHLCV velas  →  Binance REST API
 2. Calcular indicadores  →  RSI, MACD, BB, EMA (9/21/50/200), Volumen, S&R
 3. Obtener noticias  →  CryptoPanic / NewsData / RSS
-4. LLM analysis  →  Claude / OpenAI / Groq
+4. AgentConfigResolver  →  resolver proveedor/modelo por agente
+5. LLM analysis  →  OpenRouter / Claude / OpenAI / Groq / Gemini / Mistral / Together
          prompt: indicadores + velas + noticias + historial últimas 10 ops
          respuesta: { decision, confidence, reasoning, waitMinutes }
-5. ¿confidence ≥ threshold?  →  Ejecutar orden BUY/SELL en Binance
-6. Guardar AgentDecision + Trade + actualizar Position en DB
-7. Emitir eventos WebSocket al dashboard
-8. Reprogramar próximo análisis según waitMinutes
+6. ¿confidence ≥ threshold?  →  Ejecutar orden BUY/SELL en Binance
+7. Guardar AgentDecision + Trade + actualizar Position en DB
+8. Emitir eventos WebSocket al dashboard
+9. Reprogramar próximo análisis según waitMinutes
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ Plataforma fullstack de **trading autónomo de criptomonedas** impulsada por un 
 
 ## Stack
 
-| Capa | Tecnología |
-|------|-----------|
-| Monorepo | NX 22 + pnpm workspaces |
-| Frontend | React 19, Vite, React Router, TanStack Query, Zustand |
-| UI / Animaciones | Tailwind CSS, GSAP, Lucide React, lightweight-charts |
-| Backend | NestJS 11, Bull queues, Socket.io |
-| ORM / DB | Prisma 7, PostgreSQL 16 |
-| Cache / Colas | Redis 7 |
-| Auth | JWT (15min) + refresh tokens, bcrypt |
-| LLM | OpenRouter (`@openrouter/sdk`), Claude, OpenAI, Groq, Gemini, Mistral, Together — por usuario |
-| Trading API | Binance REST + WebSocket |
-| Tests | Vitest (frontend), Jest (backend), Playwright (E2E) |
-| CI/CD | GitHub Actions → GitHub Pages (web) + Railway (api) |
+| Capa             | Tecnología                                                                                    |
+| ---------------- | --------------------------------------------------------------------------------------------- |
+| Monorepo         | NX 22 + pnpm workspaces                                                                       |
+| Frontend         | React 19, Vite, React Router, TanStack Query, Zustand                                         |
+| UI / Animaciones | Tailwind CSS, GSAP, Lucide React, lightweight-charts                                          |
+| Backend          | NestJS 11, Bull queues, Socket.io                                                             |
+| ORM / DB         | Prisma 7, PostgreSQL 16                                                                       |
+| Cache / Colas    | Redis 7                                                                                       |
+| Auth             | JWT (15min) + refresh tokens, bcrypt                                                          |
+| LLM              | OpenRouter (`@openrouter/sdk`), Claude, OpenAI, Groq, Gemini, Mistral, Together — por usuario |
+| Trading API      | Binance REST + WebSocket                                                                      |
+| Tests            | Vitest (frontend), Jest (backend), Playwright (E2E)                                           |
+| CI/CD            | GitHub Actions → GitHub Pages (web) + Railway (api)                                           |
 
 ---
 
@@ -195,23 +195,23 @@ Cada N minutos (adaptativo por volatilidad):
 
 ## Despliegue
 
-| Entorno | Servicio | Trigger |
-|---------|----------|---------|
-| Frontend (prod) | GitHub Pages | Push a `main` |
-| Backend (prod) | Railway | Push a `main` |
-| DB + Cache | Railway (PostgreSQL 16 + Redis 7) | Provisionado manualmente |
-| Local dev | Docker Compose | `pnpm docker:infra` |
+| Entorno         | Servicio                          | Trigger                  |
+| --------------- | --------------------------------- | ------------------------ |
+| Frontend (prod) | GitHub Pages                      | Push a `main`            |
+| Backend (prod)  | Railway                           | Push a `main`            |
+| DB + Cache      | Railway (PostgreSQL 16 + Redis 7) | Provisionado manualmente |
+| Local dev       | Docker Compose                    | `pnpm docker:infra`      |
 
 ---
 
 ## Documentación
 
-| Documento | Descripción |
-|-----------|-------------|
-| [docs/CONSTITUTION.md](docs/CONSTITUTION.md) | Arquitectura, stack detallado, convenciones y decisiones |
-| [docs/specs/crypto-trader-spec.md](docs/specs/crypto-trader-spec.md) | Especificación completa v1.2 |
-| [docs/plans/crypto-trader-implementation-plan.md](docs/plans/crypto-trader-implementation-plan.md) | Plan de implementación por tareas |
-| `http://localhost:3000/api/docs` | Swagger / OpenAPI (solo en dev) |
+| Documento                                                                                          | Descripción                                              |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [docs/CONSTITUTION.md](docs/CONSTITUTION.md)                                                       | Arquitectura, stack detallado, convenciones y decisiones |
+| [docs/specs/crypto-trader-spec.md](docs/specs/crypto-trader-spec.md)                               | Especificación completa v1.2                             |
+| [docs/plans/crypto-trader-implementation-plan.md](docs/plans/crypto-trader-implementation-plan.md) | Plan de implementación por tareas                        |
+| `http://localhost:3000/api/docs`                                                                   | Swagger / OpenAPI (solo en dev)                          |
 
 ---
 

--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -19,5 +19,7 @@ module.exports = {
       '<rootDir>/../../libs/data-fetcher/src/index.ts',
     '^@crypto-trader/trading-engine$':
       '<rootDir>/../../libs/trading-engine/src/index.ts',
+    '^@crypto-trader/openrouter$':
+      '<rootDir>/src/__mocks__/crypto-trader-openrouter.ts',
   },
 };

--- a/apps/api/prisma/migrations/20260422170309_add_platform_llm_providers/migration.sql
+++ b/apps/api/prisma/migrations/20260422170309_add_platform_llm_providers/migration.sql
@@ -1,0 +1,16 @@
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'LLM_PROVIDER_DISABLED';
+
+-- CreateTable
+CREATE TABLE "platform_llm_providers" (
+    "id" TEXT NOT NULL,
+    "provider" "LLMProvider" NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedBy" TEXT,
+
+    CONSTRAINT "platform_llm_providers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "platform_llm_providers_provider_key" ON "platform_llm_providers"("provider");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -84,6 +84,7 @@ enum DocumentStatus {
   AGENT_STARTED
   AGENT_STOPPED
   AGENT_KILLED
+  LLM_PROVIDER_DISABLED
 }
 
 enum LLMProvider {
@@ -398,6 +399,18 @@ model AdminAction {
 
   @@index([adminId, createdAt])
   @@map("admin_actions")
+}
+
+/// Global toggle for LLM providers — admin can enable/disable providers platform-wide.
+/// Seeded with all LLMProvider enum values on first migration.
+model PlatformLLMProvider {
+  id        String      @id @default(cuid())
+  provider  LLMProvider @unique
+  isActive  Boolean     @default(true)
+  updatedAt DateTime    @updatedAt
+  updatedBy String?
+
+  @@map("platform_llm_providers")
 }
 
 /// Virtual wallet for SANDBOX paper trading.

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -156,6 +156,19 @@ async function main() {
       }
     }
 
+    // ── PlatformLLMProvider: seed all providers as active (Spec 38) ──────────
+    const allProviders = Object.values(LLMProvider);
+    for (const provider of allProviders) {
+      await prisma.platformLLMProvider.upsert({
+        where: { provider },
+        update: {},
+        create: { provider, isActive: true },
+      });
+    }
+    console.log(
+      `PlatformLLMProvider seeded: ${allProviders.length} providers (all active)`,
+    );
+
     console.log('\n✅ Seed completado!');
     console.log('─────────────────────────────────────────');
     console.log('  admin@crypto.com        / Admin1234!  (ADMIN)');

--- a/apps/api/src/__mocks__/crypto-trader-openrouter.ts
+++ b/apps/api/src/__mocks__/crypto-trader-openrouter.ts
@@ -1,0 +1,43 @@
+/**
+ * Mock for @crypto-trader/openrouter
+ * Avoids importing the ESM @openrouter/sdk in Jest.
+ */
+
+export interface OpenRouterModelInfo {
+  id: string;
+  name: string;
+  contextLength: number;
+  maxCompletionTokens: number | null;
+  pricing: { prompt: number; completion: number };
+  isFree: boolean;
+  categories: string[];
+  supportedParameters: string[];
+  description?: string;
+}
+
+export interface OpenRouterModelsFilter {
+  category?: string;
+  freeOnly?: boolean;
+  textOnly?: boolean;
+}
+
+export class OpenRouterModelsService {
+  async listModels(
+    _filter?: OpenRouterModelsFilter,
+  ): Promise<OpenRouterModelInfo[]> {
+    return [];
+  }
+  async getFreeModels(): Promise<OpenRouterModelInfo[]> {
+    return [];
+  }
+  async getModelById(_id: string): Promise<OpenRouterModelInfo | null> {
+    return null;
+  }
+  async isModelAvailable(_id: string): Promise<boolean> {
+    return false;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  invalidateCache(): void {}
+}
+
+export const OPENROUTER_DEFAULT_CACHE_TTL = 15 * 60 * 1000;

--- a/apps/api/src/agents/agent-config.controller.ts
+++ b/apps/api/src/agents/agent-config.controller.ts
@@ -110,4 +110,13 @@ export class AgentConfigController {
       preset as 'free' | 'optimized' | 'balanced',
     );
   }
+
+  @Post('config/resolve-fallback')
+  @ApiOperation({
+    summary:
+      'Auto-resolve the best fallback model from live OpenRouter catalog',
+  })
+  resolveFallback(@CurrentUser() user: RequestUser) {
+    return this.agentConfigService.autoResolveFallback(user.userId);
+  }
 }

--- a/apps/api/src/agents/agent-config.module.ts
+++ b/apps/api/src/agents/agent-config.module.ts
@@ -4,9 +4,10 @@ import { AgentConfigResolverService } from './agent-config-resolver.service';
 import { AgentConfigController } from './agent-config.controller';
 import { AdminAgentConfigController } from './admin-agent-config.controller';
 import { PrismaModule } from '../prisma/prisma.module';
+import { OpenRouterModule } from '../openrouter/openrouter.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, OpenRouterModule],
   controllers: [AgentConfigController, AdminAgentConfigController],
   providers: [AgentConfigService, AgentConfigResolverService],
   exports: [AgentConfigService, AgentConfigResolverService],

--- a/apps/api/src/agents/agent-config.service.ts
+++ b/apps/api/src/agents/agent-config.service.ts
@@ -5,11 +5,21 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AgentId, LLMProvider } from '../../generated/prisma/enums';
-import { AGENT_PRESETS, AgentPresetName } from './agent-presets';
+import {
+  AGENT_PRESETS_STATIC,
+  AgentPresetName,
+  STATIC_FALLBACK_MODEL,
+  buildDynamicPreset,
+  resolveFallbackModel,
+} from './agent-presets';
+import { OpenRouterModelsApiService } from '../openrouter/openrouter-models-api.service';
 
 @Injectable()
 export class AgentConfigService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly openRouterModels: OpenRouterModelsApiService,
+  ) {}
 
   // ── User configs ───────────────────────────────────────────────────────────
 
@@ -73,12 +83,18 @@ export class AgentConfigService {
   // ── Presets ────────────────────────────────────────────────────────────────
 
   async applyPreset(userId: string, presetName: AgentPresetName) {
-    const preset = AGENT_PRESETS[presetName];
-    if (!preset) {
+    if (!['free', 'optimized', 'balanced'].includes(presetName)) {
       throw new BadRequestException(
         `Unknown preset "${presetName}". Valid values: free, optimized, balanced`,
       );
     }
+
+    // Resolve preset dynamically from live OpenRouter models
+    const models = await this.openRouterModels.getModels();
+    const preset =
+      models.length > 0
+        ? buildDynamicPreset(presetName, models)
+        : AGENT_PRESETS_STATIC[presetName];
 
     const results: Array<{ agentId: string; provider: string; model: string }> =
       [];
@@ -101,7 +117,58 @@ export class AgentConfigService {
       results.push({ agentId, provider: entry.provider, model: entry.model });
     }
 
-    return { applied: presetName, count: results.length, agents: results };
+    // Also update the fallback model on the user's OpenRouter credential
+    const fallbackModel =
+      models.length > 0
+        ? resolveFallbackModel(presetName, models)
+        : STATIC_FALLBACK_MODEL;
+
+    let appliedFallback: string | null = null;
+    if (fallbackModel) {
+      const updated = await this.prisma.lLMCredential.updateMany({
+        where: {
+          userId,
+          provider: LLMProvider.OPENROUTER,
+          isActive: true,
+        },
+        data: { selectedModel: fallbackModel },
+      });
+      if (updated.count > 0) appliedFallback = fallbackModel;
+    }
+
+    return {
+      applied: presetName,
+      count: results.length,
+      agents: results,
+      fallbackModel: appliedFallback,
+    };
+  }
+
+  /**
+   * Auto-resolve the best fallback model from the live OpenRouter catalog
+   * and save it to the user's OpenRouter credential.
+   */
+  async autoResolveFallback(
+    userId: string,
+  ): Promise<{ fallbackModel: string }> {
+    const models = await this.openRouterModels.getModels();
+    const resolved =
+      models.length > 0
+        ? resolveFallbackModel('balanced', models)
+        : STATIC_FALLBACK_MODEL;
+
+    const fallbackModel = resolved ?? STATIC_FALLBACK_MODEL;
+
+    await this.prisma.lLMCredential.updateMany({
+      where: {
+        userId,
+        provider: LLMProvider.OPENROUTER,
+        isActive: true,
+      },
+      data: { selectedModel: fallbackModel },
+    });
+
+    return { fallbackModel };
   }
 
   // ── Admin configs ──────────────────────────────────────────────────────────
@@ -141,12 +208,18 @@ export class AgentConfigService {
   }
 
   async applyAdminPreset(presetName: AgentPresetName, adminUserId: string) {
-    const preset = AGENT_PRESETS[presetName];
-    if (!preset) {
+    if (!['free', 'optimized', 'balanced'].includes(presetName)) {
       throw new BadRequestException(
         `Unknown preset "${presetName}". Valid values: free, optimized, balanced`,
       );
     }
+
+    // Resolve preset dynamically from live OpenRouter models
+    const models = await this.openRouterModels.getModels();
+    const preset =
+      models.length > 0
+        ? buildDynamicPreset(presetName, models)
+        : AGENT_PRESETS_STATIC[presetName];
     const results: AgentId[] = [];
     for (const [agentIdStr, entry] of Object.entries(preset)) {
       const agentId = agentIdStr as AgentId;
@@ -166,6 +239,31 @@ export class AgentConfigService {
       });
       results.push(agentId);
     }
-    return { applied: presetName, count: results.length, agents: results };
+
+    // Also update the fallback model on the admin's OpenRouter credential
+    const fallbackModel =
+      models.length > 0
+        ? resolveFallbackModel(presetName, models)
+        : STATIC_FALLBACK_MODEL;
+
+    let appliedFallback: string | null = null;
+    if (fallbackModel) {
+      const updated = await this.prisma.lLMCredential.updateMany({
+        where: {
+          userId: adminUserId,
+          provider: LLMProvider.OPENROUTER,
+          isActive: true,
+        },
+        data: { selectedModel: fallbackModel },
+      });
+      if (updated.count > 0) appliedFallback = fallbackModel;
+    }
+
+    return {
+      applied: presetName,
+      count: results.length,
+      agents: results,
+      fallbackModel: appliedFallback,
+    };
   }
 }

--- a/apps/api/src/agents/agent-presets.spec.ts
+++ b/apps/api/src/agents/agent-presets.spec.ts
@@ -1,0 +1,105 @@
+import { buildDynamicPreset, AgentPresetName } from './agent-presets';
+import type { OpenRouterModelInfo } from '@crypto-trader/openrouter';
+
+function makeModel(
+  overrides: Partial<OpenRouterModelInfo> & { id: string },
+): OpenRouterModelInfo {
+  return {
+    name: overrides.id,
+    contextLength: 128_000,
+    maxCompletionTokens: null,
+    pricing: { prompt: 0, completion: 0 },
+    isFree: true,
+    categories: [],
+    supportedParameters: [],
+    ...overrides,
+  };
+}
+
+describe('buildDynamicPreset', () => {
+  const freeModel = makeModel({
+    id: 'free/model-a:free',
+    isFree: true,
+    categories: ['free', 'reasoning'],
+    contextLength: 200_000,
+    supportedParameters: ['reasoning'],
+  });
+
+  const cheapPaid = makeModel({
+    id: 'vendor/cheap-paid',
+    isFree: false,
+    categories: ['paid', 'fast', 'tool-use'],
+    pricing: { prompt: 0.5, completion: 2 },
+    contextLength: 128_000,
+    supportedParameters: ['tools'],
+  });
+
+  const premiumPaid = makeModel({
+    id: 'vendor/premium-model',
+    isFree: false,
+    categories: ['paid', 'reasoning', 'tool-use', 'premium', 'long-context'],
+    pricing: { prompt: 5, completion: 15 },
+    contextLength: 1_000_000,
+    supportedParameters: ['reasoning', 'include_reasoning', 'tools'],
+  });
+
+  const models = [freeModel, cheapPaid, premiumPaid];
+
+  it('free preset should only select free models', () => {
+    const preset = buildDynamicPreset('free', models);
+    for (const entry of Object.values(preset)) {
+      expect(entry!.model).toBe('free/model-a:free');
+    }
+  });
+
+  it('optimized preset should select paid models for all agents', () => {
+    const preset = buildDynamicPreset('optimized', models);
+    for (const entry of Object.values(preset)) {
+      expect(entry!.model).not.toContain(':free');
+    }
+  });
+
+  it('balanced preset should mix free and paid', () => {
+    const preset = buildDynamicPreset('balanced', models);
+    const modelIds = Object.values(preset).map((e) => e!.model);
+    const hasFree = modelIds.some((id) => id.includes(':free'));
+    const hasPaid = modelIds.some((id) => !id.includes(':free'));
+    expect(hasFree).toBe(true);
+    expect(hasPaid).toBe(true);
+  });
+
+  it('should cover all 8 agent roles', () => {
+    for (const presetName of [
+      'free',
+      'optimized',
+      'balanced',
+    ] as AgentPresetName[]) {
+      const preset = buildDynamicPreset(presetName, models);
+      expect(Object.keys(preset).length).toBe(8);
+    }
+  });
+
+  it('should return empty preset for unknown name', () => {
+    const preset = buildDynamicPreset('nonexistent' as AgentPresetName, models);
+    expect(Object.keys(preset).length).toBe(0);
+  });
+
+  it('optimized should prefer premium reasoning for risk agent', () => {
+    const preset = buildDynamicPreset('optimized', models);
+    // Risk agent requires reasoning + premium preference
+    expect(preset.risk?.model).toBe('vendor/premium-model');
+  });
+
+  it('optimized should prefer tool-use for operations agent', () => {
+    const preset = buildDynamicPreset('optimized', models);
+    // Operations requires tool-use
+    expect(preset.operations).toBeDefined();
+    const selectedModel = models.find((m) => m.id === preset.operations?.model);
+    expect(selectedModel?.categories).toContain('tool-use');
+  });
+
+  it('should handle empty model list', () => {
+    const preset = buildDynamicPreset('free', []);
+    expect(Object.keys(preset).length).toBe(0);
+  });
+});

--- a/apps/api/src/agents/agent-presets.ts
+++ b/apps/api/src/agents/agent-presets.ts
@@ -1,4 +1,5 @@
 import { AgentId, LLMProvider } from '../../generated/prisma/enums';
+import type { OpenRouterModelInfo } from '@crypto-trader/openrouter';
 
 export type AgentPresetName = 'free' | 'optimized' | 'balanced';
 
@@ -9,10 +10,325 @@ export interface AgentPresetEntry {
 
 export type AgentPreset = Partial<Record<AgentId, AgentPresetEntry>>;
 
+// ── Selection criteria per agent role ───────────────────────────────────────
+
 /**
- * Set Gratuito — 100% modelos free en OpenRouter (abril 2026)
- * Fuente: openrouter.ai/models?max_price=0&order=top-weekly
+ * Each agent role has specific requirements. These criteria define what makes
+ * a good model for each role, scored against the live OpenRouter catalog.
  */
+interface AgentModelCriteria {
+  /** true = only free models, false = only paid, undefined = any */
+  freeOnly?: boolean;
+  /** Required categories the model MUST have (all must match) */
+  requiredCategories?: string[];
+  /** Preferred categories that boost the score (any match) */
+  preferredCategories?: string[];
+  /** Minimum context length */
+  minContext?: number;
+  /** Weight for price (lower = cheaper preferred). 0-1 */
+  priceWeight: number;
+  /** Weight for context length. 0-1 */
+  contextWeight: number;
+  /** Weight for reasoning capability. 0-1 */
+  reasoningWeight: number;
+}
+
+/**
+ * Criteria definitions for each preset × agent combination.
+ *
+ * FREE: all agents use free models, prioritize context length
+ * OPTIMIZED: best paid model per role function
+ * BALANCED: free where sufficient, paid where quality matters
+ */
+const PRESET_CRITERIA: Record<
+  AgentPresetName,
+  Partial<Record<AgentId, AgentModelCriteria>>
+> = {
+  free: {
+    [AgentId.routing]: {
+      freeOnly: true,
+      priceWeight: 0,
+      contextWeight: 0.3,
+      reasoningWeight: 0.7,
+    },
+    [AgentId.orchestrator]: {
+      freeOnly: true,
+      preferredCategories: ['reasoning'],
+      priceWeight: 0,
+      contextWeight: 0.4,
+      reasoningWeight: 0.6,
+    },
+    [AgentId.synthesis]: {
+      freeOnly: true,
+      preferredCategories: ['reasoning'],
+      priceWeight: 0,
+      contextWeight: 0.5,
+      reasoningWeight: 0.5,
+    },
+    [AgentId.platform]: {
+      freeOnly: true,
+      priceWeight: 0,
+      contextWeight: 0.6,
+      reasoningWeight: 0.4,
+    },
+    [AgentId.operations]: {
+      freeOnly: true,
+      preferredCategories: ['tool-use'],
+      priceWeight: 0,
+      contextWeight: 0.4,
+      reasoningWeight: 0.6,
+    },
+    [AgentId.market]: {
+      freeOnly: true,
+      preferredCategories: ['reasoning'],
+      priceWeight: 0,
+      contextWeight: 0.5,
+      reasoningWeight: 0.5,
+    },
+    [AgentId.blockchain]: {
+      freeOnly: true,
+      priceWeight: 0,
+      contextWeight: 0.5,
+      reasoningWeight: 0.5,
+    },
+    [AgentId.risk]: {
+      freeOnly: true,
+      preferredCategories: ['reasoning'],
+      priceWeight: 0,
+      contextWeight: 0.3,
+      reasoningWeight: 0.7,
+    },
+  },
+  optimized: {
+    [AgentId.routing]: {
+      freeOnly: false,
+      preferredCategories: ['fast'],
+      priceWeight: 0.6,
+      contextWeight: 0.1,
+      reasoningWeight: 0.3,
+    },
+    [AgentId.orchestrator]: {
+      freeOnly: false,
+      preferredCategories: ['reasoning', 'tool-use'],
+      minContext: 128_000,
+      priceWeight: 0.2,
+      contextWeight: 0.3,
+      reasoningWeight: 0.5,
+    },
+    [AgentId.synthesis]: {
+      freeOnly: false,
+      preferredCategories: ['reasoning', 'premium'],
+      minContext: 128_000,
+      priceWeight: 0.1,
+      contextWeight: 0.3,
+      reasoningWeight: 0.6,
+    },
+    [AgentId.platform]: {
+      freeOnly: false,
+      preferredCategories: ['fast'],
+      priceWeight: 0.5,
+      contextWeight: 0.3,
+      reasoningWeight: 0.2,
+    },
+    [AgentId.operations]: {
+      freeOnly: false,
+      requiredCategories: ['tool-use'],
+      priceWeight: 0.4,
+      contextWeight: 0.2,
+      reasoningWeight: 0.4,
+    },
+    [AgentId.market]: {
+      freeOnly: false,
+      preferredCategories: ['reasoning'],
+      minContext: 128_000,
+      priceWeight: 0.3,
+      contextWeight: 0.3,
+      reasoningWeight: 0.4,
+    },
+    [AgentId.blockchain]: {
+      freeOnly: false,
+      preferredCategories: ['reasoning', 'tool-use'],
+      priceWeight: 0.4,
+      contextWeight: 0.2,
+      reasoningWeight: 0.4,
+    },
+    [AgentId.risk]: {
+      freeOnly: false,
+      preferredCategories: ['reasoning', 'premium'],
+      minContext: 128_000,
+      priceWeight: 0.1,
+      contextWeight: 0.2,
+      reasoningWeight: 0.7,
+    },
+  },
+  balanced: {
+    [AgentId.routing]: {
+      freeOnly: true,
+      priceWeight: 0,
+      contextWeight: 0.3,
+      reasoningWeight: 0.7,
+    },
+    [AgentId.orchestrator]: {
+      freeOnly: false,
+      preferredCategories: ['reasoning', 'tool-use'],
+      priceWeight: 0.4,
+      contextWeight: 0.2,
+      reasoningWeight: 0.4,
+    },
+    [AgentId.synthesis]: {
+      freeOnly: false,
+      preferredCategories: ['reasoning'],
+      priceWeight: 0.3,
+      contextWeight: 0.3,
+      reasoningWeight: 0.4,
+    },
+    [AgentId.platform]: {
+      freeOnly: true,
+      priceWeight: 0,
+      contextWeight: 0.5,
+      reasoningWeight: 0.5,
+    },
+    [AgentId.operations]: {
+      freeOnly: false,
+      preferredCategories: ['tool-use'],
+      priceWeight: 0.5,
+      contextWeight: 0.2,
+      reasoningWeight: 0.3,
+    },
+    [AgentId.market]: {
+      freeOnly: false,
+      preferredCategories: ['reasoning'],
+      priceWeight: 0.5,
+      contextWeight: 0.2,
+      reasoningWeight: 0.3,
+    },
+    [AgentId.blockchain]: {
+      freeOnly: true,
+      preferredCategories: ['reasoning'],
+      priceWeight: 0,
+      contextWeight: 0.4,
+      reasoningWeight: 0.6,
+    },
+    [AgentId.risk]: {
+      freeOnly: false,
+      preferredCategories: ['reasoning'],
+      priceWeight: 0.3,
+      contextWeight: 0.2,
+      reasoningWeight: 0.5,
+    },
+  },
+};
+
+// ── Scoring engine ──────────────────────────────────────────────────────────
+
+function scoreModel(
+  model: OpenRouterModelInfo,
+  criteria: AgentModelCriteria,
+): number {
+  // Exclude meta-models / routers (e.g. openrouter/auto, openrouter/free)
+  if (model.id.startsWith('openrouter/')) return -1;
+
+  // Exclude models with invalid pricing (negative = variable/unknown)
+  if (model.pricing.prompt < 0 || model.pricing.completion < 0) return -1;
+
+  // Hard filters
+  if (criteria.freeOnly === true && !model.isFree) return -1;
+  if (criteria.freeOnly === false && model.isFree) return -1;
+  if (criteria.minContext && model.contextLength < criteria.minContext)
+    return -1;
+  if (criteria.requiredCategories) {
+    for (const cat of criteria.requiredCategories) {
+      if (!model.categories.includes(cat)) return -1;
+    }
+  }
+
+  let score = 0;
+
+  // Price score: cheaper = better (normalize to 0-1 range, cap at $100/M)
+  const maxPrice = 100;
+  const priceScore = model.isFree
+    ? 1
+    : 1 - Math.min(model.pricing.completion, maxPrice) / maxPrice;
+  score += priceScore * criteria.priceWeight;
+
+  // Context score: longer = better (normalize, cap at 2M)
+  const maxCtx = 2_000_000;
+  const ctxScore = Math.min(model.contextLength, maxCtx) / maxCtx;
+  score += ctxScore * criteria.contextWeight;
+
+  // Reasoning score: has reasoning or include_reasoning params
+  const hasReasoning =
+    model.categories.includes('reasoning') ||
+    model.supportedParameters.includes('reasoning') ||
+    model.supportedParameters.includes('include_reasoning');
+  score += (hasReasoning ? 1 : 0) * criteria.reasoningWeight;
+
+  // Bonus for preferred categories (up to 0.3 extra)
+  if (criteria.preferredCategories) {
+    const matched = criteria.preferredCategories.filter((c) =>
+      model.categories.includes(c),
+    ).length;
+    score += (matched / criteria.preferredCategories.length) * 0.3;
+  }
+
+  return score;
+}
+
+/**
+ * Build a preset dynamically from live OpenRouter model data.
+ * Returns the best model for each agent role based on weighted criteria.
+ * Uses progressive penalization to encourage model diversity across agents.
+ */
+export function buildDynamicPreset(
+  presetName: AgentPresetName,
+  models: OpenRouterModelInfo[],
+): AgentPreset {
+  const criteria = PRESET_CRITERIA[presetName];
+  if (!criteria) return {};
+
+  const preset: AgentPreset = {};
+  // Track how many times each model has been assigned to penalize reuse
+  const assignedCount = new Map<string, number>();
+
+  for (const [agentIdStr, agentCriteria] of Object.entries(criteria)) {
+    const agentId = agentIdStr as AgentId;
+
+    let bestModel: OpenRouterModelInfo | null = null;
+    let bestScore = -1;
+
+    for (const model of models) {
+      let s = scoreModel(model, agentCriteria);
+      if (s <= 0) continue;
+
+      // Penalize models already assigned to other agents (−30% per reuse)
+      const reuses = assignedCount.get(model.id) ?? 0;
+      if (reuses > 0) {
+        s *= Math.pow(0.7, reuses);
+      }
+
+      if (s > bestScore) {
+        bestScore = s;
+        bestModel = model;
+      }
+    }
+
+    if (bestModel) {
+      preset[agentId] = {
+        provider: LLMProvider.OPENROUTER,
+        model: bestModel.id,
+      };
+      assignedCount.set(
+        bestModel.id,
+        (assignedCount.get(bestModel.id) ?? 0) + 1,
+      );
+    }
+  }
+
+  return preset;
+}
+
+// ── Legacy static presets (fallback when API is unavailable) ────────────────
+
 export const PRESET_FREE: AgentPreset = {
   [AgentId.routing]: {
     provider: LLMProvider.OPENROUTER,
@@ -36,7 +352,7 @@ export const PRESET_FREE: AgentPreset = {
   },
   [AgentId.market]: {
     provider: LLMProvider.OPENROUTER,
-    model: 'openrouter/elephant-alpha',
+    model: 'inclusionai/ling-2.6-flash:free',
   },
   [AgentId.blockchain]: {
     provider: LLMProvider.OPENROUTER,
@@ -48,103 +364,68 @@ export const PRESET_FREE: AgentPreset = {
   },
 };
 
-/**
- * Set Optimizado de Pago — mejores modelos de pago para cada rol (abril 2026)
- *
- * routing     → gemini-2.5-flash-lite   ultra-fast, bajo costo, ideal clasificación
- * orchestrator→ gemini-3-flash-preview  agentic multi-turn, tool use, razonamiento
- * synthesis   → claude-sonnet-4.6       mejor síntesis y coherencia del mercado
- * platform    → gemini-2.5-flash-lite   multilingual, pedagogical, bajo costo
- * operations  → deepseek-v3.2           tool use nativo, agentic, bajo precio
- * market      → gemini-3-flash-preview  reasoning + data analysis + multimodal
- * blockchain  → deepseek-v3.2           razonamiento técnico profundo, bajo precio
- * risk        → claude-sonnet-4.6       chain-of-thought, veredictos estructurados
- */
-export const PRESET_OPTIMIZED: AgentPreset = {
-  [AgentId.routing]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemini-2.5-flash-lite',
-  },
-  [AgentId.orchestrator]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemini-3-flash-preview',
-  },
-  [AgentId.synthesis]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'anthropic/claude-sonnet-4.6',
-  },
-  [AgentId.platform]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemini-2.5-flash-lite',
-  },
-  [AgentId.operations]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'deepseek/deepseek-v3.2',
-  },
-  [AgentId.market]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemini-3-flash-preview',
-  },
-  [AgentId.blockchain]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'deepseek/deepseek-v3.2',
-  },
-  [AgentId.risk]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'anthropic/claude-sonnet-4.6',
-  },
-};
-
-/**
- * Set Equilibrado — mix óptimo calidad/costo (gratuitos donde son suficientes,
- * de pago donde la diferencia de calidad justifica el costo)
- *
- * routing     → nemotron-nano-9b:free   suficientemente rápido para clasificación
- * orchestrator→ gemini-3-flash-preview  coordinación multi-agente requiere calidad
- * synthesis   → gemini-3-flash-preview  síntesis compleja, justifica el costo
- * platform    → gemma-4-31b-it:free     soporte y guía, free es suficiente
- * operations  → deepseek-v3.2           tool use crítico, bajo costo de pago
- * market      → gemini-2.5-flash-lite   análisis cuantitativo, buena relación precio/calidad
- * blockchain  → minimax-m2.5:free       conocimiento técnico, free es suficiente
- * risk        → deepseek-v3.2           veredictos críticos con razonamiento superior
- */
-export const PRESET_BALANCED: AgentPreset = {
-  [AgentId.routing]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'nvidia/nemotron-nano-9b-v2:free',
-  },
-  [AgentId.orchestrator]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemini-3-flash-preview',
-  },
-  [AgentId.synthesis]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemini-3-flash-preview',
-  },
-  [AgentId.platform]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemma-4-31b-it:free',
-  },
-  [AgentId.operations]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'deepseek/deepseek-v3.2',
-  },
-  [AgentId.market]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemini-2.5-flash-lite',
-  },
-  [AgentId.blockchain]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'minimax/minimax-m2.5:free',
-  },
-  [AgentId.risk]: {
-    provider: LLMProvider.OPENROUTER,
-    model: 'deepseek/deepseek-v3.2',
-  },
-};
-
-export const AGENT_PRESETS: Record<AgentPresetName, AgentPreset> = {
+export const AGENT_PRESETS_STATIC: Record<AgentPresetName, AgentPreset> = {
   free: PRESET_FREE,
-  optimized: PRESET_OPTIMIZED,
-  balanced: PRESET_BALANCED,
+  optimized: PRESET_FREE, // fallback to free if API is down
+  balanced: PRESET_FREE,
 };
+
+// ── Fallback model resolution ───────────────────────────────────────────────
+
+/**
+ * Criteria for a universal fallback model — must be a versatile all-rounder
+ * that can handle any agent's work when no specific config exists.
+ */
+const FALLBACK_MODEL_CRITERIA: Record<AgentPresetName, AgentModelCriteria> = {
+  free: {
+    freeOnly: true,
+    preferredCategories: ['reasoning', 'tool-use', 'long-context'],
+    minContext: 32_000,
+    priceWeight: 0,
+    contextWeight: 0.4,
+    reasoningWeight: 0.6,
+  },
+  optimized: {
+    freeOnly: false,
+    preferredCategories: ['reasoning', 'tool-use', 'long-context', 'premium'],
+    minContext: 128_000,
+    priceWeight: 0.1,
+    contextWeight: 0.3,
+    reasoningWeight: 0.6,
+  },
+  balanced: {
+    preferredCategories: ['reasoning', 'tool-use', 'long-context'],
+    minContext: 64_000,
+    priceWeight: 0.3,
+    contextWeight: 0.3,
+    reasoningWeight: 0.4,
+  },
+};
+
+/**
+ * Resolve the best universal fallback model from the live OpenRouter catalog.
+ * The preset name controls the criteria (free → free only, optimized → best paid, etc).
+ */
+export function resolveFallbackModel(
+  presetName: AgentPresetName,
+  models: OpenRouterModelInfo[],
+): string | null {
+  const criteria = FALLBACK_MODEL_CRITERIA[presetName];
+  if (!criteria || models.length === 0) return null;
+
+  let bestModel: OpenRouterModelInfo | null = null;
+  let bestScore = -1;
+
+  for (const model of models) {
+    const s = scoreModel(model, criteria);
+    if (s > bestScore) {
+      bestScore = s;
+      bestModel = model;
+    }
+  }
+
+  return bestModel?.id ?? null;
+}
+
+/** Static fallback model ID used when the API is unavailable */
+export const STATIC_FALLBACK_MODEL = 'nvidia/nemotron-3-super-120b-a12b:free';

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -210,6 +210,12 @@ export class AnalyticsService {
         }
       }
 
+      // Extract LLM provider/model from decision metadata (if saved), otherwise fall back to active credential
+      const decisionMeta = d.metadata as {
+        llmProvider?: string;
+        llmModel?: string;
+      } | null;
+
       return {
         ...d,
         metadata: undefined, // don't leak raw metadata to frontend
@@ -233,8 +239,8 @@ export class AnalyticsService {
               updatedAt: cfg.updatedAt,
             }
           : null,
-        llmProvider: activeLlm?.provider ?? null,
-        llmModel: activeLlm?.selectedModel ?? null,
+        llmProvider: decisionMeta?.llmProvider ?? activeLlm?.provider ?? null,
+        llmModel: decisionMeta?.llmModel ?? activeLlm?.selectedModel ?? null,
       };
     });
   }

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { MarketModule } from '../market/market.module';
 import { ChatModule } from '../chat/chat.module';
 import { LlmModule } from '../llm/llm.module';
 import { AgentConfigModule } from '../agents/agent-config.module';
+import { OpenRouterModule } from '../openrouter/openrouter.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { AgentConfigModule } from '../agents/agent-config.module';
     ChatModule,
     LlmModule,
     AgentConfigModule,
+    OpenRouterModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -69,16 +69,10 @@ const PROVIDER_MODELS: Record<LLMProvider, string[]> = {
     'meta-llama/Llama-3.3-70B-Instruct-Turbo',
   ],
   [LLMProvider.OPENROUTER]: [
-    // Top Paid
+    // Resolved dynamically via OpenRouterModelsService at runtime.
+    // Static fallbacks only used if dynamic fetch fails.
     'anthropic/claude-sonnet-4.6',
     'google/gemini-3-flash-preview',
-    'anthropic/claude-opus-4.6',
-    'deepseek/deepseek-v3.2',
-    'google/gemini-2.5-flash-lite',
-    // Top Free
-    'openrouter/elephant-alpha',
-    'nvidia/nemotron-3-super-120b-a12b:free',
-    'google/gemma-4-31b-it:free',
   ],
 };
 

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -24,6 +24,7 @@ import { RagService } from '../orchestrator/rag.service';
 import { LLMModelsService } from '../llm/llm-models.service';
 import { LLMUsageService } from '../llm/llm-usage.service';
 import { AgentConfigResolverService } from '../agents/agent-config-resolver.service';
+import { PlatformLLMProviderService } from '../llm/platform-llm-provider.service';
 
 const PROVIDER_LABELS: Record<LLMProvider, string> = {
   [LLMProvider.CLAUDE]: 'Anthropic Claude',
@@ -113,6 +114,8 @@ export class ChatService {
     @Optional() private readonly llmUsageService?: LLMUsageService,
     @Optional()
     private readonly agentConfigResolver?: AgentConfigResolverService,
+    @Optional()
+    private readonly platformLLMProviderService?: PlatformLLMProviderService,
   ) {}
 
   // ── Sessions ────────────────────────────────────────────────────────────────
@@ -517,6 +520,18 @@ export class ChatService {
 
     const generatedBy = `${effectiveProvider}:${effectiveModel}`;
 
+    // Emit resolved provider/model to client (Spec 38, B.6)
+    subject.next(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          type: 'routing',
+          agentId: activeAgentId,
+          provider: effectiveProvider,
+          model: effectiveModel,
+        }),
+      }),
+    );
+
     // Update session with resolved provider/model (for display)
     await this.prisma.chatSession.update({
       where: { id: sessionId },
@@ -537,6 +552,29 @@ export class ChatService {
       subject.complete();
       return;
     }
+
+    // Validate provider is active at platform level (Spec 38)
+    if (this.platformLLMProviderService) {
+      try {
+        await this.platformLLMProviderService.assertProviderActive(
+          effectiveProvider,
+        );
+      } catch (err) {
+        subject.next(
+          new MessageEvent('message', {
+            data: JSON.stringify({
+              error:
+                err instanceof Error
+                  ? err.message
+                  : `Provider ${effectiveProvider} is disabled`,
+            }),
+          }),
+        );
+        subject.complete();
+        return;
+      }
+    }
+
     const apiKey = decrypt(cred.apiKeyEncrypted, cred.apiKeyIv);
 
     // Last 30 messages for context

--- a/apps/api/src/llm/llm-models.service.spec.ts
+++ b/apps/api/src/llm/llm-models.service.spec.ts
@@ -5,6 +5,36 @@ import { PrismaService } from '../prisma/prisma.service';
 
 jest.mock('@prisma/adapter-pg', () => ({ PrismaPg: jest.fn() }));
 
+jest.mock('@crypto-trader/openrouter', () => ({
+  OpenRouterModelsService: jest.fn().mockImplementation(() => ({
+    listModels: jest.fn().mockResolvedValue([
+      {
+        id: 'test/model-1',
+        name: 'Test Model 1',
+        contextLength: 128000,
+        maxCompletionTokens: 8192,
+        pricing: { prompt: 3, completion: 15 },
+        isFree: false,
+        categories: ['programming'],
+        supportedParameters: ['temperature'],
+        description: 'Test',
+      },
+      {
+        id: 'test/free-model:free',
+        name: 'Free Model',
+        contextLength: 32000,
+        maxCompletionTokens: 4096,
+        pricing: { prompt: 0, completion: 0 },
+        isFree: true,
+        categories: [],
+        supportedParameters: [],
+        description: '',
+      },
+    ]),
+    invalidateCache: jest.fn(),
+  })),
+}));
+
 jest.mock('../users/utils/encryption.util', () => ({
   decrypt: jest.fn(() => 'decrypted-api-key'),
 }));

--- a/apps/api/src/llm/llm-models.service.ts
+++ b/apps/api/src/llm/llm-models.service.ts
@@ -9,6 +9,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { LLMProvider } from '../../generated/prisma/enums';
 import { decrypt } from '../users/utils/encryption.util';
 import { MODEL_PRICING } from './model-pricing';
+import { OpenRouterModelsService } from '@crypto-trader/openrouter';
 
 interface ProviderModel {
   id: string;
@@ -35,6 +36,7 @@ export class LLMModelsService {
     { data: ProviderModel[]; fetchedAt: number }
   >();
   private readonly CACHE_TTL = 5 * 60 * 1000;
+  private readonly openRouterModels = new OpenRouterModelsService();
 
   constructor(private readonly prisma: PrismaService) {}
 
@@ -271,74 +273,31 @@ export class LLMModelsService {
       );
   }
 
-  private async fetchOpenRouter(apiKey: string): Promise<ProviderModel[]> {
-    const { data } = await axios.get('https://openrouter.ai/api/v1/models', {
-      headers: { Authorization: `Bearer ${apiKey}` },
-      timeout: 15000,
-    });
+  private async fetchOpenRouter(_apiKey: string): Promise<ProviderModel[]> {
+    const models = await this.openRouterModels.listModels({ textOnly: true });
 
-    const textModels = (data.data ?? []).filter(
-      (m: any) =>
-        m.id &&
-        m.architecture?.modality === 'text->text' &&
-        m.top_provider?.is_moderated !== undefined &&
-        !m.expiration_date, // exclude deprecated/expiring models
-    );
-
-    // Sort by weekly usage (position in API response = popularity) and build models
-    const models: ProviderModel[] = textModels.slice(0, 150).map((m: any) => {
-      const inputPrice = m.pricing
-        ? parseFloat(m.pricing.prompt) * 1_000_000
-        : 0;
-      const outputPrice = m.pricing
-        ? parseFloat(m.pricing.completion) * 1_000_000
-        : 0;
-      const isFree = inputPrice === 0 && outputPrice === 0;
-      const supportedParams: string[] = m.supported_parameters ?? [];
-      const hasReasoning =
-        supportedParams.includes('reasoning') ||
-        supportedParams.includes('include_reasoning');
-      const hasTools = supportedParams.includes('tools');
-      const contextLen = m.context_length ?? 128_000;
-
-      // Dynamic category classification
-      const categories: string[] = [];
-      if (isFree) categories.push('free');
-      if (!isFree) categories.push('paid');
-      if (hasReasoning) categories.push('reasoning');
-      if (hasTools) categories.push('analytics');
-      // "fast" heuristic: low price + high context or known fast providers
-      if ((inputPrice < 1.0 && outputPrice < 5.0) || isFree) {
-        categories.push('fast');
-      }
-
-      return {
-        id: m.id,
-        name: m.name ?? m.id,
-        contextWindow: contextLen,
-        pricing: { input: inputPrice, output: outputPrice },
-        deprecated: false,
-        recommended: MODEL_PRICING[m.id]?.recommended ?? false,
-        categories,
-      } as ProviderModel;
-    });
-
-    // Build top-paid: non-free sorted by output price desc (most capable first), limit 10
-    const paidModels = models.filter((m) => m.categories?.includes('paid'));
+    // Build top-paid: non-free sorted by output price desc, limit 10
+    const paidModels = models.filter((m) => !m.isFree);
     const topPaidIds = new Set(
       [...paidModels]
-        .sort((a, b) => (b.pricing?.output ?? 0) - (a.pricing?.output ?? 0))
+        .sort((a, b) => b.pricing.completion - a.pricing.completion)
         .slice(0, 10)
         .map((m) => m.id),
     );
 
-    // Tag top-paid
-    for (const m of models) {
-      if (topPaidIds.has(m.id)) {
-        m.categories!.push('top-paid');
-      }
-    }
+    return models.slice(0, 150).map((m) => {
+      const categories: string[] = [...m.categories];
+      if (topPaidIds.has(m.id)) categories.push('top-paid');
 
-    return models;
+      return {
+        id: m.id,
+        name: m.name,
+        contextWindow: m.contextLength,
+        pricing: { input: m.pricing.prompt, output: m.pricing.completion },
+        deprecated: false,
+        recommended: false,
+        categories,
+      } as ProviderModel;
+    });
   }
 }

--- a/apps/api/src/llm/llm.module.ts
+++ b/apps/api/src/llm/llm.module.ts
@@ -1,12 +1,29 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { LLMUsageService } from './llm-usage.service';
 import { LLMModelsService } from './llm-models.service';
 import { ProviderHealthService } from './provider-health.service';
+import { PlatformLLMProviderService } from './platform-llm-provider.service';
+import {
+  PlatformLLMProviderController,
+  LLMProviderStatusController,
+} from './platform-llm-provider.controller';
 
 @Module({
-  imports: [PrismaModule],
-  providers: [LLMUsageService, LLMModelsService, ProviderHealthService],
-  exports: [LLMUsageService, LLMModelsService, ProviderHealthService],
+  imports: [PrismaModule, NotificationsModule],
+  controllers: [PlatformLLMProviderController, LLMProviderStatusController],
+  providers: [
+    LLMUsageService,
+    LLMModelsService,
+    ProviderHealthService,
+    PlatformLLMProviderService,
+  ],
+  exports: [
+    LLMUsageService,
+    LLMModelsService,
+    ProviderHealthService,
+    PlatformLLMProviderService,
+  ],
 })
 export class LlmModule {}

--- a/apps/api/src/llm/model-pricing.ts
+++ b/apps/api/src/llm/model-pricing.ts
@@ -239,58 +239,7 @@ export const MODEL_PRICING: Record<
     contextWindow: 131_072,
     recommended: true,
   },
-  // ── OpenRouter — Top Paid (prices from openrouter.ai, Apr 2026) ──
-  'anthropic/claude-sonnet-4.6': {
-    input: 3.0,
-    output: 15.0,
-    label: 'Claude Sonnet 4.6 (OpenRouter)',
-    contextWindow: 1_000_000,
-    recommended: true,
-  },
-  'google/gemini-3-flash-preview': {
-    input: 0.5,
-    output: 3.0,
-    label: 'Gemini 3 Flash Preview (OpenRouter)',
-    contextWindow: 1_000_000,
-    recommended: true,
-  },
-  'anthropic/claude-opus-4.6': {
-    input: 5.0,
-    output: 25.0,
-    label: 'Claude Opus 4.6 (OpenRouter)',
-    contextWindow: 1_000_000,
-  },
-  'deepseek/deepseek-v3.2': {
-    input: 0.259,
-    output: 0.42,
-    label: 'DeepSeek V3.2 (OpenRouter)',
-    contextWindow: 164_000,
-    recommended: true,
-  },
-  'google/gemini-2.5-flash-lite': {
-    input: 0.1,
-    output: 0.4,
-    label: 'Gemini 2.5 Flash Lite (OpenRouter)',
-    contextWindow: 1_000_000,
-  },
-  // ── OpenRouter — Top Free ──
-  'openrouter/elephant-alpha': {
-    input: 0,
-    output: 0,
-    label: 'Elephant Alpha (OpenRouter, free)',
-    contextWindow: 262_000,
-    recommended: true,
-  },
-  'nvidia/nemotron-3-super-120b-a12b:free': {
-    input: 0,
-    output: 0,
-    label: 'Nemotron 3 Super 120B (OpenRouter, free)',
-    contextWindow: 262_000,
-  },
-  'google/gemma-4-31b-it:free': {
-    input: 0,
-    output: 0,
-    label: 'Gemma 4 31B (OpenRouter, free)',
-    contextWindow: 262_000,
-  },
+  // ── OpenRouter ──────────────────────────────────────────
+  // OpenRouter models are resolved dynamically via @crypto-trader/openrouter.
+  // No hardcoded entries — pricing comes from the OpenRouter API at runtime.
 };

--- a/apps/api/src/llm/model-ranking.spec.ts
+++ b/apps/api/src/llm/model-ranking.spec.ts
@@ -1,10 +1,17 @@
 import { LLMProvider } from '../../generated/prisma/enums';
-import { MODEL_RANKING, suggestModel, suggestModels } from './model-ranking';
+import {
+  MODEL_RANKING,
+  suggestModel,
+  suggestModels,
+  openRouterModelToRank,
+  buildDynamicRanking,
+  suggestModelDynamic,
+} from './model-ranking';
 
 describe('model-ranking', () => {
   describe('MODEL_RANKING', () => {
-    it('should contain 28 ranked models', () => {
-      expect(MODEL_RANKING).toHaveLength(28);
+    it('should contain 20 ranked models (no OpenRouter)', () => {
+      expect(MODEL_RANKING).toHaveLength(20);
     });
 
     it('should be sorted by intelligenceScore descending', () => {
@@ -15,13 +22,10 @@ describe('model-ranking', () => {
       }
     });
 
-    it('should include all 7 providers', () => {
+    it('should NOT include OPENROUTER in static ranking', () => {
       const providers = new Set(MODEL_RANKING.map((m) => m.provider));
-      expect(providers).toContain(LLMProvider.CLAUDE);
-      expect(providers).toContain(LLMProvider.OPENAI);
-      expect(providers).toContain(LLMProvider.OPENROUTER);
-      expect(providers).toBeInstanceOf(Set);
-      expect(providers.size).toBe(7);
+      expect(providers).not.toContain(LLMProvider.OPENROUTER);
+      expect(providers.size).toBe(6);
     });
   });
 
@@ -39,8 +43,8 @@ describe('model-ranking', () => {
     it('should return the highest intelligence model for TRADING', () => {
       const result = suggestModel(allProviders, 'TRADING');
       expect(result).not.toBeNull();
-      // Claude Opus 4.6 (OpenRouter) scores 58
-      expect(result!.intelligenceScore).toBe(58);
+      // Gemini 3.1 Pro Preview scores 57 (top static TRADING model)
+      expect(result!.intelligenceScore).toBe(57);
     });
 
     it('should filter by active providers only', () => {
@@ -71,9 +75,8 @@ describe('model-ranking', () => {
     it('should break cost ties by intelligence score (preferCheap)', () => {
       const result = suggestModel(allProviders, 'NEWS', true);
       expect(result).not.toBeNull();
-      // Among FREE models for NEWS: Elephant Alpha (30), Nemotron 3 Super (28)
-      // Highest intelligence among cheapest (FREE) = Elephant Alpha (30)
-      expect(result!.model).toBe('openrouter/elephant-alpha');
+      // Among cheapest models for NEWS — picks CHEAP tier first
+      expect(['CHEAP', 'FREE']).toContain(result!.costTier);
     });
 
     it('should return highest intelligence when preferCheap is false', () => {
@@ -129,6 +132,102 @@ describe('model-ranking', () => {
       results.forEach((r) => {
         expect(r.bestFor).toContain('CLASSIFY');
       });
+    });
+  });
+
+  describe('openRouterModelToRank', () => {
+    it('should convert an OpenRouterModelInfo to a ModelRank', () => {
+      const model = {
+        id: 'test/model-1',
+        name: 'Test Model',
+        contextLength: 128000,
+        maxCompletionTokens: 8192,
+        pricing: { prompt: 3, completion: 15 },
+        isFree: false,
+        categories: ['programming', 'finance'],
+        supportedParameters: ['temperature'],
+        description: 'A test model',
+      };
+      const rank = openRouterModelToRank(model);
+      expect(rank.model).toBe('test/model-1');
+      expect(rank.provider).toBe(LLMProvider.OPENROUTER);
+      expect(rank.label).toBe('Test Model');
+      expect(rank.costTier).toBe('PREMIUM');
+      expect(rank.bestFor).toContain('TRADING');
+    });
+
+    it('should mark free models with FREE cost tier', () => {
+      const model = {
+        id: 'test/free-model:free',
+        name: 'Free Model',
+        contextLength: 32000,
+        maxCompletionTokens: 4096,
+        pricing: { prompt: 0, completion: 0 },
+        isFree: true,
+        categories: [],
+        supportedParameters: [],
+        description: '',
+      };
+      const rank = openRouterModelToRank(model);
+      expect(rank.costTier).toBe('FREE');
+    });
+  });
+
+  describe('buildDynamicRanking', () => {
+    it('should combine static + dynamic and sort by score', () => {
+      const orModels = [
+        {
+          id: 'anthropic/claude-sonnet-4.6',
+          name: 'Claude Sonnet 4.6',
+          contextLength: 200000,
+          maxCompletionTokens: 8192,
+          pricing: { prompt: 3, completion: 15 },
+          isFree: false,
+          categories: ['programming'],
+          supportedParameters: ['temperature'],
+          description: '',
+        },
+      ];
+      const combined = buildDynamicRanking(orModels);
+      expect(combined.length).toBe(MODEL_RANKING.length + 1);
+      // Should be sorted
+      for (let i = 1; i < combined.length; i++) {
+        expect(combined[i - 1].intelligenceScore).toBeGreaterThanOrEqual(
+          combined[i].intelligenceScore,
+        );
+      }
+    });
+  });
+
+  describe('suggestModelDynamic', () => {
+    const orModels = [
+      {
+        id: 'anthropic/claude-sonnet-4.6',
+        name: 'Claude Sonnet 4.6',
+        contextLength: 200000,
+        maxCompletionTokens: 8192,
+        pricing: { prompt: 3, completion: 15 },
+        isFree: false,
+        categories: ['programming', 'finance'],
+        supportedParameters: ['temperature'],
+        description: '',
+      },
+    ];
+
+    it('should suggest from combined ranking when OPENROUTER is active', () => {
+      const result = suggestModelDynamic(
+        [LLMProvider.OPENROUTER],
+        'TRADING',
+        orModels,
+      );
+      expect(result).not.toBeNull();
+      expect(result!.provider).toBe(LLMProvider.OPENROUTER);
+    });
+
+    it('should fallback to static models when no OpenRouter models available', () => {
+      const result = suggestModelDynamic([LLMProvider.CLAUDE], 'TRADING', []);
+      expect(result).not.toBeNull();
+      expect(result!.provider).toBe(LLMProvider.CLAUDE);
     });
   });
 });

--- a/apps/api/src/llm/model-ranking.ts
+++ b/apps/api/src/llm/model-ranking.ts
@@ -1,4 +1,5 @@
 import { LLMProvider } from '../../generated/prisma/enums';
+import type { OpenRouterModelInfo } from '@crypto-trader/openrouter';
 
 export interface ModelRank {
   provider: LLMProvider;
@@ -20,16 +21,7 @@ const COST_ORDER: Record<ModelRank['costTier'], number> = {
 
 export const MODEL_RANKING: ModelRank[] = [
   // ── Tier FRONTIER (Intelligence ≥ 44) ──────────────────────────────────
-  {
-    provider: LLMProvider.OPENROUTER,
-    model: 'anthropic/claude-opus-4.6',
-    label: 'Claude Opus 4.6 (OpenRouter)',
-    intelligenceScore: 58,
-    tier: 'FRONTIER',
-    speed: 'SLOW',
-    costTier: 'PREMIUM',
-    bestFor: ['TRADING', 'CHAT'],
-  },
+  // OpenRouter models are resolved dynamically — see buildDynamicRanking()
   {
     provider: LLMProvider.GEMINI,
     model: 'gemini-3.1-pro-preview',
@@ -49,16 +41,6 @@ export const MODEL_RANKING: ModelRank[] = [
     speed: 'SLOW',
     costTier: 'PREMIUM',
     bestFor: ['TRADING'],
-  },
-  {
-    provider: LLMProvider.OPENROUTER,
-    model: 'anthropic/claude-sonnet-4.6',
-    label: 'Claude Sonnet 4.6 (OpenRouter)',
-    intelligenceScore: 56,
-    tier: 'FRONTIER',
-    speed: 'MEDIUM',
-    costTier: 'STANDARD',
-    bestFor: ['TRADING', 'CHAT', 'NEWS'],
   },
   {
     provider: LLMProvider.CLAUDE,
@@ -81,16 +63,6 @@ export const MODEL_RANKING: ModelRank[] = [
     bestFor: ['TRADING', 'CHAT', 'NEWS'],
   },
   {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemini-3-flash-preview',
-    label: 'Gemini 3 Flash (OpenRouter)',
-    intelligenceScore: 50,
-    tier: 'FRONTIER',
-    speed: 'FAST',
-    costTier: 'CHEAP',
-    bestFor: ['TRADING', 'CHAT', 'NEWS'],
-  },
-  {
     provider: LLMProvider.OPENAI,
     model: 'gpt-5.4-mini',
     label: 'GPT-5.4 Mini',
@@ -108,16 +80,6 @@ export const MODEL_RANKING: ModelRank[] = [
     tier: 'FRONTIER',
     speed: 'FAST',
     costTier: 'STANDARD',
-    bestFor: ['TRADING', 'CHAT', 'NEWS'],
-  },
-  {
-    provider: LLMProvider.OPENROUTER,
-    model: 'deepseek/deepseek-v3.2',
-    label: 'DeepSeek V3.2 (OpenRouter)',
-    intelligenceScore: 45,
-    tier: 'FRONTIER',
-    speed: 'FAST',
-    costTier: 'CHEAP',
     bestFor: ['TRADING', 'CHAT', 'NEWS'],
   },
   {
@@ -173,16 +135,6 @@ export const MODEL_RANKING: ModelRank[] = [
     bestFor: ['NEWS', 'CLASSIFY'],
   },
   {
-    provider: LLMProvider.OPENROUTER,
-    model: 'openrouter/elephant-alpha',
-    label: 'Elephant Alpha (OpenRouter, free)',
-    intelligenceScore: 30,
-    tier: 'STRONG',
-    speed: 'FAST',
-    costTier: 'FREE',
-    bestFor: ['NEWS', 'CLASSIFY', 'CHAT'],
-  },
-  {
     provider: LLMProvider.MISTRAL,
     model: 'mistral-small-latest',
     label: 'Mistral Small 4',
@@ -191,16 +143,6 @@ export const MODEL_RANKING: ModelRank[] = [
     speed: 'FAST',
     costTier: 'CHEAP',
     bestFor: ['NEWS', 'CLASSIFY', 'CHAT'],
-  },
-  {
-    provider: LLMProvider.OPENROUTER,
-    model: 'nvidia/nemotron-3-super-120b-a12b:free',
-    label: 'Nemotron 3 Super (OpenRouter, free)',
-    intelligenceScore: 28,
-    tier: 'STRONG',
-    speed: 'MEDIUM',
-    costTier: 'FREE',
-    bestFor: ['NEWS', 'CLASSIFY'],
   },
   {
     provider: LLMProvider.TOGETHER,
@@ -245,16 +187,6 @@ export const MODEL_RANKING: ModelRank[] = [
     bestFor: ['NEWS', 'CLASSIFY'],
   },
   {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemini-2.5-flash-lite',
-    label: 'Gemini 2.5 Flash Lite (OpenRouter)',
-    intelligenceScore: 22,
-    tier: 'BUDGET',
-    speed: 'FAST',
-    costTier: 'CHEAP',
-    bestFor: ['NEWS', 'CLASSIFY'],
-  },
-  {
     provider: LLMProvider.MISTRAL,
     model: 'mistral-medium-latest',
     label: 'Mistral Medium 3.1',
@@ -263,16 +195,6 @@ export const MODEL_RANKING: ModelRank[] = [
     speed: 'MEDIUM',
     costTier: 'STANDARD',
     bestFor: ['CHAT'],
-  },
-  {
-    provider: LLMProvider.OPENROUTER,
-    model: 'google/gemma-4-31b-it:free',
-    label: 'Gemma 4 31B (OpenRouter, free)',
-    intelligenceScore: 20,
-    tier: 'BUDGET',
-    speed: 'FAST',
-    costTier: 'FREE',
-    bestFor: ['CLASSIFY'],
   },
   {
     provider: LLMProvider.TOGETHER,
@@ -344,4 +266,99 @@ export function suggestModels(
   return MODEL_RANKING.filter(
     (m) => activeProviders.includes(m.provider) && m.bestFor.includes(useCase),
   ).slice(0, limit);
+}
+
+/**
+ * Convert an OpenRouter model from the dynamic API into a ModelRank.
+ * Uses heuristic scoring based on pricing and context length.
+ */
+export function openRouterModelToRank(model: OpenRouterModelInfo): ModelRank {
+  const { pricing, contextLength, isFree } = model;
+
+  // Heuristic intelligence score based on pricing (higher price ≈ more capable)
+  let intelligenceScore: number;
+  if (isFree) {
+    intelligenceScore = contextLength >= 200_000 ? 25 : 18;
+  } else if (pricing.completion >= 10.0) {
+    intelligenceScore = 55;
+  } else if (pricing.completion >= 3.0) {
+    intelligenceScore = 48;
+  } else if (pricing.completion >= 1.0) {
+    intelligenceScore = 38;
+  } else {
+    intelligenceScore = 30;
+  }
+
+  // Tier
+  let tier: ModelRank['tier'];
+  if (intelligenceScore >= 44) tier = 'FRONTIER';
+  else if (intelligenceScore >= 28) tier = 'STRONG';
+  else tier = 'BUDGET';
+
+  // Cost tier
+  let costTier: ModelRank['costTier'];
+  if (isFree) costTier = 'FREE';
+  else if (pricing.completion < 1.0) costTier = 'CHEAP';
+  else if (pricing.completion < 10.0) costTier = 'STANDARD';
+  else costTier = 'PREMIUM';
+
+  // Speed heuristic based on pricing (cheaper models tend to be faster)
+  let speed: ModelRank['speed'];
+  if (isFree || pricing.completion < 1.0) speed = 'FAST';
+  else if (pricing.completion < 5.0) speed = 'MEDIUM';
+  else speed = 'SLOW';
+
+  // All OpenRouter models can potentially serve any use case
+  const bestFor: ModelRank['bestFor'] = ['TRADING', 'CHAT', 'NEWS', 'CLASSIFY'];
+
+  return {
+    provider: LLMProvider.OPENROUTER,
+    model: model.id,
+    label: model.name,
+    intelligenceScore,
+    tier,
+    speed,
+    costTier,
+    bestFor,
+  };
+}
+
+/**
+ * Build a combined ranking from static native providers + dynamic OpenRouter models.
+ * Returns a new array sorted by intelligenceScore desc.
+ */
+export function buildDynamicRanking(
+  openRouterModels: OpenRouterModelInfo[],
+): ModelRank[] {
+  const dynamicRanks = openRouterModels.map(openRouterModelToRank);
+  return [...MODEL_RANKING, ...dynamicRanks].sort(
+    (a, b) => b.intelligenceScore - a.intelligenceScore,
+  );
+}
+
+/**
+ * suggestModel variant that includes dynamic OpenRouter models.
+ */
+export function suggestModelDynamic(
+  activeProviders: LLMProvider[],
+  useCase: 'TRADING' | 'CHAT' | 'NEWS' | 'CLASSIFY',
+  openRouterModels: OpenRouterModelInfo[],
+  preferCheap = false,
+): ModelRank | null {
+  const ranking = buildDynamicRanking(openRouterModels);
+  const candidates = ranking.filter(
+    (m) => activeProviders.includes(m.provider) && m.bestFor.includes(useCase),
+  );
+
+  if (!candidates.length) return null;
+
+  if (preferCheap) {
+    return [...candidates].sort(
+      (a, b) =>
+        COST_ORDER[a.costTier] - COST_ORDER[b.costTier] ||
+        b.intelligenceScore - a.intelligenceScore,
+    )[0];
+  }
+
+  return candidates[0];
 }

--- a/apps/api/src/llm/platform-llm-provider.controller.ts
+++ b/apps/api/src/llm/platform-llm-provider.controller.ts
@@ -1,5 +1,4 @@
 import {
-  Body,
   Controller,
   Get,
   Param,
@@ -37,11 +36,7 @@ export class PlatformLLMProviderController {
   @ApiResponse({ status: 200, description: 'Toggle result with impact' })
   @ApiResponse({ status: 400, description: 'Invalid provider' })
   @ApiResponse({ status: 404, description: 'Provider not found' })
-  toggle(
-    @Param('provider') provider: string,
-    @Body() dto: { isActive: boolean },
-    @Req() req: any,
-  ) {
+  toggle(@Param('provider') provider: string, @Req() req: any) {
     // Validate provider is a valid enum value
     if (!Object.values(LLMProvider).includes(provider as LLMProvider)) {
       throw new BadRequestException(`Invalid LLM provider: ${provider}`);
@@ -49,7 +44,6 @@ export class PlatformLLMProviderController {
 
     return this.platformLLMProviderService.toggle(
       provider as LLMProvider,
-      dto.isActive,
       req.user.userId,
     );
   }

--- a/apps/api/src/llm/platform-llm-provider.controller.ts
+++ b/apps/api/src/llm/platform-llm-provider.controller.ts
@@ -1,0 +1,72 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Put,
+  Req,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { PlatformLLMProviderService } from './platform-llm-provider.service';
+import { LLMProvider } from '../../generated/prisma/enums';
+
+@ApiTags('admin')
+@Controller('admin/llm-providers')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+export class PlatformLLMProviderController {
+  constructor(
+    private readonly platformLLMProviderService: PlatformLLMProviderService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: '[ADMIN] List all LLM providers with their status' })
+  @ApiResponse({ status: 200, description: 'List of providers' })
+  getAll() {
+    return this.platformLLMProviderService.getAll();
+  }
+
+  @Put(':provider/toggle')
+  @ApiOperation({ summary: '[ADMIN] Toggle LLM provider active status' })
+  @ApiParam({ name: 'provider', description: 'LLM provider enum value' })
+  @ApiResponse({ status: 200, description: 'Toggle result with impact' })
+  @ApiResponse({ status: 400, description: 'Invalid provider' })
+  @ApiResponse({ status: 404, description: 'Provider not found' })
+  toggle(
+    @Param('provider') provider: string,
+    @Body() dto: { isActive: boolean },
+    @Req() req: any,
+  ) {
+    // Validate provider is a valid enum value
+    if (!Object.values(LLMProvider).includes(provider as LLMProvider)) {
+      throw new BadRequestException(`Invalid LLM provider: ${provider}`);
+    }
+
+    return this.platformLLMProviderService.toggle(
+      provider as LLMProvider,
+      dto.isActive,
+      req.user.userId,
+    );
+  }
+}
+
+@ApiTags('llm')
+@Controller('llm-providers')
+@UseGuards(JwtAuthGuard)
+export class LLMProviderStatusController {
+  constructor(
+    private readonly platformLLMProviderService: PlatformLLMProviderService,
+  ) {}
+
+  @Get('status')
+  @ApiOperation({ summary: 'Get platform LLM provider status' })
+  @ApiResponse({ status: 200, description: 'List of providers with status' })
+  getStatus() {
+    return this.platformLLMProviderService.getAll();
+  }
+}

--- a/apps/api/src/llm/platform-llm-provider.service.spec.ts
+++ b/apps/api/src/llm/platform-llm-provider.service.spec.ts
@@ -1,0 +1,272 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  PlatformLLMProviderService,
+  ToggleResult,
+} from './platform-llm-provider.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { NotificationsService } from '../notifications/notifications.service';
+
+jest.mock('../../generated/prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock('@prisma/adapter-pg', () => ({ PrismaPg: jest.fn() }));
+jest.mock('../../generated/prisma/enums', () => ({
+  LLMProvider: {
+    CLAUDE: 'CLAUDE',
+    OPENAI: 'OPENAI',
+    GROQ: 'GROQ',
+    GEMINI: 'GEMINI',
+    MISTRAL: 'MISTRAL',
+    TOGETHER: 'TOGETHER',
+    OPENROUTER: 'OPENROUTER',
+  },
+  NotificationType: {
+    TRADE_EXECUTED: 'TRADE_EXECUTED',
+    STOP_LOSS_TRIGGERED: 'STOP_LOSS_TRIGGERED',
+    TAKE_PROFIT_HIT: 'TAKE_PROFIT_HIT',
+    AGENT_ERROR: 'AGENT_ERROR',
+    AGENT_STARTED: 'AGENT_STARTED',
+    AGENT_STOPPED: 'AGENT_STOPPED',
+    AGENT_KILLED: 'AGENT_KILLED',
+    LLM_PROVIDER_DISABLED: 'LLM_PROVIDER_DISABLED',
+  },
+}));
+
+// Use string values since the enum module may not load correctly under jest mocks
+const LLMProvider = {
+  CLAUDE: 'CLAUDE' as any,
+  OPENAI: 'OPENAI' as any,
+  GROQ: 'GROQ' as any,
+  OPENROUTER: 'OPENROUTER' as any,
+};
+const NotificationType = {
+  LLM_PROVIDER_DISABLED: 'LLM_PROVIDER_DISABLED' as any,
+};
+
+const mockPrisma = {
+  platformLLMProvider: {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  adminAction: {
+    create: jest.fn(),
+  },
+  agentConfig: {
+    findMany: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+};
+
+const mockNotifications = {
+  create: jest.fn(),
+};
+
+describe('PlatformLLMProviderService', () => {
+  let service: PlatformLLMProviderService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PlatformLLMProviderService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: NotificationsService, useValue: mockNotifications },
+      ],
+    }).compile();
+    service = module.get<PlatformLLMProviderService>(
+      PlatformLLMProviderService,
+    );
+  });
+
+  describe('getAll', () => {
+    it('should return all providers ordered by provider', async () => {
+      const providers = [
+        { id: '1', provider: 'CLAUDE', isActive: true },
+        { id: '2', provider: 'OPENAI', isActive: true },
+      ];
+      mockPrisma.platformLLMProvider.findMany.mockResolvedValue(providers);
+
+      const result = await service.getAll();
+      expect(result).toEqual(providers);
+      expect(mockPrisma.platformLLMProvider.findMany).toHaveBeenCalledWith({
+        orderBy: { provider: 'asc' },
+      });
+    });
+  });
+
+  describe('getActiveProviders', () => {
+    it('should return only active provider enums', async () => {
+      mockPrisma.platformLLMProvider.findMany.mockResolvedValue([
+        { provider: 'CLAUDE' },
+        { provider: 'OPENROUTER' },
+      ]);
+
+      const result = await service.getActiveProviders();
+      expect(result).toEqual(['CLAUDE', 'OPENROUTER']);
+    });
+  });
+
+  describe('isProviderActive', () => {
+    it('should return true for active provider', async () => {
+      mockPrisma.platformLLMProvider.findUnique.mockResolvedValue({
+        isActive: true,
+      });
+
+      expect(await service.isProviderActive(LLMProvider.CLAUDE)).toBe(true);
+    });
+
+    it('should return false for inactive provider', async () => {
+      mockPrisma.platformLLMProvider.findUnique.mockResolvedValue({
+        isActive: false,
+      });
+
+      expect(await service.isProviderActive(LLMProvider.GROQ)).toBe(false);
+    });
+
+    it('should return true if no record exists', async () => {
+      mockPrisma.platformLLMProvider.findUnique.mockResolvedValue(null);
+
+      expect(await service.isProviderActive(LLMProvider.CLAUDE)).toBe(true);
+    });
+  });
+
+  describe('assertProviderActive', () => {
+    it('should not throw for active provider', async () => {
+      mockPrisma.platformLLMProvider.findUnique.mockResolvedValue({
+        isActive: true,
+      });
+
+      await expect(
+        service.assertProviderActive(LLMProvider.CLAUDE),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw ConflictException for inactive provider', async () => {
+      mockPrisma.platformLLMProvider.findUnique.mockResolvedValue({
+        isActive: false,
+      });
+
+      await expect(
+        service.assertProviderActive(LLMProvider.GROQ),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should not throw if no record exists', async () => {
+      mockPrisma.platformLLMProvider.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.assertProviderActive(LLMProvider.CLAUDE),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('toggle', () => {
+    const adminId = 'admin-1';
+
+    it('should enable provider with no side effects', async () => {
+      mockPrisma.platformLLMProvider.findUnique.mockResolvedValue({
+        provider: LLMProvider.GROQ,
+        isActive: false,
+      });
+      mockPrisma.platformLLMProvider.update.mockResolvedValue({});
+      mockPrisma.adminAction.create.mockResolvedValue({});
+
+      const result: ToggleResult = await service.toggle(
+        LLMProvider.GROQ,
+        true,
+        adminId,
+      );
+
+      expect(result).toEqual({
+        provider: LLMProvider.GROQ,
+        isActive: true,
+        affectedAgentConfigs: 0,
+        affectedUsers: 0,
+      });
+      expect(mockPrisma.platformLLMProvider.update).toHaveBeenCalledWith({
+        where: { provider: LLMProvider.GROQ },
+        data: { isActive: true, updatedBy: adminId },
+      });
+      expect(mockPrisma.adminAction.create).toHaveBeenCalledWith({
+        data: {
+          adminId,
+          action: 'ENABLE_PROVIDER',
+          details: { provider: LLMProvider.GROQ },
+        },
+      });
+      // No agent configs affected on enable
+      expect(mockPrisma.agentConfig.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should disable provider, delete affected configs, and notify users', async () => {
+      mockPrisma.platformLLMProvider.findUnique.mockResolvedValue({
+        provider: LLMProvider.GROQ,
+        isActive: true,
+      });
+      mockPrisma.platformLLMProvider.update.mockResolvedValue({});
+      mockPrisma.adminAction.create.mockResolvedValue({});
+      mockPrisma.agentConfig.findMany.mockResolvedValue([
+        { id: 'cfg-1', userId: 'user-1' },
+        { id: 'cfg-2', userId: 'user-1' },
+        { id: 'cfg-3', userId: 'user-2' },
+      ]);
+      mockPrisma.agentConfig.deleteMany.mockResolvedValue({ count: 3 });
+      mockNotifications.create.mockResolvedValue({});
+
+      const result: ToggleResult = await service.toggle(
+        LLMProvider.GROQ,
+        false,
+        adminId,
+      );
+
+      expect(result).toEqual({
+        provider: LLMProvider.GROQ,
+        isActive: false,
+        affectedAgentConfigs: 3,
+        affectedUsers: 2,
+      });
+      expect(mockPrisma.agentConfig.deleteMany).toHaveBeenCalledWith({
+        where: { provider: LLMProvider.GROQ },
+      });
+      // 2 unique users notified
+      expect(mockNotifications.create).toHaveBeenCalledTimes(2);
+      expect(mockNotifications.create).toHaveBeenCalledWith(
+        'user-1',
+        NotificationType.LLM_PROVIDER_DISABLED,
+        expect.any(String),
+      );
+      expect(mockNotifications.create).toHaveBeenCalledWith(
+        'user-2',
+        NotificationType.LLM_PROVIDER_DISABLED,
+        expect.any(String),
+      );
+    });
+
+    it('should disable with no affected configs', async () => {
+      mockPrisma.platformLLMProvider.findUnique.mockResolvedValue({
+        provider: LLMProvider.CLAUDE,
+        isActive: true,
+      });
+      mockPrisma.platformLLMProvider.update.mockResolvedValue({});
+      mockPrisma.adminAction.create.mockResolvedValue({});
+      mockPrisma.agentConfig.findMany.mockResolvedValue([]);
+
+      const result = await service.toggle(LLMProvider.CLAUDE, false, adminId);
+
+      expect(result.affectedAgentConfigs).toBe(0);
+      expect(result.affectedUsers).toBe(0);
+      expect(mockPrisma.agentConfig.deleteMany).not.toHaveBeenCalled();
+      expect(mockNotifications.create).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException for unknown provider', async () => {
+      mockPrisma.platformLLMProvider.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.toggle(LLMProvider.GROQ, false, adminId),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/llm/platform-llm-provider.service.spec.ts
+++ b/apps/api/src/llm/platform-llm-provider.service.spec.ts
@@ -175,7 +175,6 @@ describe('PlatformLLMProviderService', () => {
 
       const result: ToggleResult = await service.toggle(
         LLMProvider.GROQ,
-        true,
         adminId,
       );
 
@@ -217,7 +216,6 @@ describe('PlatformLLMProviderService', () => {
 
       const result: ToggleResult = await service.toggle(
         LLMProvider.GROQ,
-        false,
         adminId,
       );
 
@@ -253,7 +251,7 @@ describe('PlatformLLMProviderService', () => {
       mockPrisma.adminAction.create.mockResolvedValue({});
       mockPrisma.agentConfig.findMany.mockResolvedValue([]);
 
-      const result = await service.toggle(LLMProvider.CLAUDE, false, adminId);
+      const result = await service.toggle(LLMProvider.CLAUDE, adminId);
 
       expect(result.affectedAgentConfigs).toBe(0);
       expect(result.affectedUsers).toBe(0);
@@ -264,9 +262,9 @@ describe('PlatformLLMProviderService', () => {
     it('should throw NotFoundException for unknown provider', async () => {
       mockPrisma.platformLLMProvider.findUnique.mockResolvedValue(null);
 
-      await expect(
-        service.toggle(LLMProvider.GROQ, false, adminId),
-      ).rejects.toThrow(NotFoundException);
+      await expect(service.toggle(LLMProvider.GROQ, adminId)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/apps/api/src/llm/platform-llm-provider.service.ts
+++ b/apps/api/src/llm/platform-llm-provider.service.ts
@@ -1,0 +1,141 @@
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import {
+  LLMProvider,
+  NotificationType,
+} from '../../generated/prisma/enums';
+import type { PlatformLLMProvider } from '../../generated/prisma/client';
+
+export interface ToggleResult {
+  provider: LLMProvider;
+  isActive: boolean;
+  affectedAgentConfigs: number;
+  affectedUsers: number;
+}
+
+@Injectable()
+export class PlatformLLMProviderService {
+  private readonly logger = new Logger(PlatformLLMProviderService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notifications: NotificationsService,
+  ) {}
+
+  async getAll(): Promise<PlatformLLMProvider[]> {
+    return this.prisma.platformLLMProvider.findMany({
+      orderBy: { provider: 'asc' },
+    });
+  }
+
+  async getActiveProviders(): Promise<LLMProvider[]> {
+    const active = await this.prisma.platformLLMProvider.findMany({
+      where: { isActive: true },
+      select: { provider: true },
+    });
+    return active.map((p) => p.provider);
+  }
+
+  async isProviderActive(provider: LLMProvider): Promise<boolean> {
+    const record = await this.prisma.platformLLMProvider.findUnique({
+      where: { provider },
+    });
+    // If no record exists (shouldn't happen after seed), assume active
+    return record?.isActive ?? true;
+  }
+
+  async assertProviderActive(provider: LLMProvider): Promise<void> {
+    const record = await this.prisma.platformLLMProvider.findUnique({
+      where: { provider },
+    });
+    if (record && !record.isActive) {
+      throw new ConflictException({
+        statusCode: 409,
+        code: 'LLM_PROVIDER_DISABLED',
+        message: `The LLM provider ${provider} has been disabled by the administrator`,
+        redirect: '/dashboard/settings/llms',
+      });
+    }
+  }
+
+  async toggle(
+    provider: LLMProvider,
+    isActive: boolean,
+    adminId: string,
+  ): Promise<ToggleResult> {
+    // Verify provider exists
+    const existing = await this.prisma.platformLLMProvider.findUnique({
+      where: { provider },
+    });
+    if (!existing) {
+      throw new NotFoundException(`Provider ${provider} not found`);
+    }
+
+    // Update provider status
+    await this.prisma.platformLLMProvider.update({
+      where: { provider },
+      data: { isActive, updatedBy: adminId },
+    });
+
+    // Log admin action
+    await this.prisma.adminAction.create({
+      data: {
+        adminId,
+        action: isActive ? 'ENABLE_PROVIDER' : 'DISABLE_PROVIDER',
+        details: { provider },
+      },
+    });
+
+    let affectedAgentConfigs = 0;
+    let affectedUsers = 0;
+
+    // If disabling: clean up affected agent configs and notify users
+    if (!isActive) {
+      // Find all agent configs using this provider
+      const affected = await this.prisma.agentConfig.findMany({
+        where: { provider },
+        select: { id: true, userId: true },
+      });
+
+      affectedAgentConfigs = affected.length;
+
+      if (affected.length > 0) {
+        // Delete affected configs — user will fall back to admin defaults
+        await this.prisma.agentConfig.deleteMany({
+          where: { provider },
+        });
+
+        // Group by userId and send one notification per user
+        const uniqueUserIds = [
+          ...new Set(affected.map((a) => a.userId)),
+        ];
+        affectedUsers = uniqueUserIds.length;
+
+        await Promise.all(
+          uniqueUserIds.map((userId) =>
+            this.notifications.create(
+              userId,
+              NotificationType.LLM_PROVIDER_DISABLED,
+              JSON.stringify({
+                key: 'llmProviderDisabled',
+                provider,
+              }),
+            ),
+          ),
+        );
+
+        this.logger.log(
+          `Disabled provider ${provider}: ${affectedAgentConfigs} configs cleared, ${affectedUsers} users notified`,
+        );
+      }
+    }
+
+    return { provider, isActive, affectedAgentConfigs, affectedUsers };
+  }
+}

--- a/apps/api/src/llm/platform-llm-provider.service.ts
+++ b/apps/api/src/llm/platform-llm-provider.service.ts
@@ -6,10 +6,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { NotificationsService } from '../notifications/notifications.service';
-import {
-  LLMProvider,
-  NotificationType,
-} from '../../generated/prisma/enums';
+import { LLMProvider, NotificationType } from '../../generated/prisma/enums';
 import type { PlatformLLMProvider } from '../../generated/prisma/client';
 
 export interface ToggleResult {
@@ -64,11 +61,7 @@ export class PlatformLLMProviderService {
     }
   }
 
-  async toggle(
-    provider: LLMProvider,
-    isActive: boolean,
-    adminId: string,
-  ): Promise<ToggleResult> {
+  async toggle(provider: LLMProvider, adminId: string): Promise<ToggleResult> {
     // Verify provider exists
     const existing = await this.prisma.platformLLMProvider.findUnique({
       where: { provider },
@@ -76,6 +69,8 @@ export class PlatformLLMProviderService {
     if (!existing) {
       throw new NotFoundException(`Provider ${provider} not found`);
     }
+
+    const isActive = !existing.isActive;
 
     // Update provider status
     await this.prisma.platformLLMProvider.update({
@@ -112,9 +107,7 @@ export class PlatformLLMProviderService {
         });
 
         // Group by userId and send one notification per user
-        const uniqueUserIds = [
-          ...new Set(affected.map((a) => a.userId)),
-        ];
+        const uniqueUserIds = [...new Set(affected.map((a) => a.userId))];
         affectedUsers = uniqueUserIds.length;
 
         await Promise.all(

--- a/apps/api/src/market/market-sentiment-ttl.spec.ts
+++ b/apps/api/src/market/market-sentiment-ttl.spec.ts
@@ -1,0 +1,155 @@
+jest.mock('../../generated/prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock('@prisma/adapter-pg', () => ({ PrismaPg: jest.fn() }));
+jest.mock('../../generated/prisma/enums', () => ({
+  LLMProvider: {
+    CLAUDE: 'CLAUDE',
+    OPENAI: 'OPENAI',
+    GROQ: 'GROQ',
+    GEMINI: 'GEMINI',
+    MISTRAL: 'MISTRAL',
+    TOGETHER: 'TOGETHER',
+    OPENROUTER: 'OPENROUTER',
+  },
+  NewsApiProvider: {
+    NEWSAPI: 'NEWSAPI',
+    NEWSDATA: 'NEWSDATA',
+    GNEWS: 'GNEWS',
+  },
+  AgentId: {
+    platform: 'platform',
+    operations: 'operations',
+    market: 'market',
+    blockchain: 'blockchain',
+    risk: 'risk',
+    orchestrator: 'orchestrator',
+    routing: 'routing',
+    synthesis: 'synthesis',
+  },
+  LLMSource: { ORCHESTRATOR: 'ORCHESTRATOR', CHAT: 'CHAT', MANUAL: 'MANUAL' },
+}));
+
+import { MarketService } from './market.service';
+
+const mockPrisma = {
+  newsConfig: { findUnique: jest.fn() },
+  newsAnalysis: {
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  lLMCredential: { findUnique: jest.fn() },
+};
+
+const mockAgentConfigResolver = {
+  resolveConfig: jest.fn(),
+};
+
+describe('MarketService.analyzeSentiment — TTL check (Spec 38, B.5)', () => {
+  let service: MarketService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new MarketService(
+      mockPrisma as any,
+      mockAgentConfigResolver as any,
+    );
+  });
+
+  it('should return existing analysis when aiAnalyzedAt is within TTL', async () => {
+    const recentAnalysis = {
+      id: 'analysis-1',
+      userId: 'user1',
+      newsCount: 5,
+      positiveCount: 2,
+      negativeCount: 1,
+      neutralCount: 2,
+      score: 60,
+      overallSentiment: 'positive',
+      summary: 'Test',
+      headlines: [],
+      aiAnalyzedAt: new Date(Date.now() - 2 * 60_000), // 2 min ago
+      aiScore: 70,
+      aiOverallSentiment: 'positive',
+      aiSummary: 'AI test',
+      aiHeadlines: [],
+    };
+
+    mockPrisma.newsConfig.findUnique.mockResolvedValue({
+      intervalMinutes: 10,
+    });
+    mockPrisma.newsAnalysis.findFirst.mockResolvedValue(recentAnalysis);
+
+    const result = await service.analyzeSentiment('user1');
+
+    expect(result).toBe(recentAnalysis);
+    // Should NOT call resolveConfig (LLM call skipped)
+    expect(mockAgentConfigResolver.resolveConfig).not.toHaveBeenCalled();
+  });
+
+  it('should proceed to LLM call when aiAnalyzedAt is older than TTL', async () => {
+    const oldAnalysis = {
+      id: 'analysis-1',
+      userId: 'user1',
+      newsCount: 5,
+      positiveCount: 2,
+      negativeCount: 1,
+      neutralCount: 2,
+      score: 60,
+      overallSentiment: 'positive',
+      summary: 'Test',
+      headlines: [
+        { id: '1', headline: 'Test news', sentiment: 'positive' },
+      ],
+      aiAnalyzedAt: new Date(Date.now() - 20 * 60_000), // 20 min ago
+      aiScore: 70,
+    };
+
+    mockPrisma.newsConfig.findUnique.mockResolvedValue({
+      intervalMinutes: 10,
+    });
+    mockPrisma.newsAnalysis.findFirst.mockResolvedValue(oldAnalysis);
+    mockAgentConfigResolver.resolveConfig.mockResolvedValue({
+      provider: 'CLAUDE',
+      model: 'claude-sonnet-4',
+    });
+    // Will fail at credential lookup — that's fine, we just check it proceeds past TTL
+    mockPrisma.lLMCredential.findUnique.mockResolvedValue(null);
+
+    await expect(service.analyzeSentiment('user1')).rejects.toThrow();
+
+    // Should call resolveConfig (proceeded past TTL)
+    expect(mockAgentConfigResolver.resolveConfig).toHaveBeenCalled();
+  });
+
+  it('should proceed when aiAnalyzedAt is null (never analyzed)', async () => {
+    const analysis = {
+      id: 'analysis-1',
+      userId: 'user1',
+      newsCount: 5,
+      positiveCount: 2,
+      negativeCount: 1,
+      neutralCount: 2,
+      score: 60,
+      overallSentiment: 'neutral',
+      summary: 'Test',
+      headlines: [{ id: '1', headline: 'Test', sentiment: 'neutral' }],
+      aiAnalyzedAt: null,
+    };
+
+    mockPrisma.newsConfig.findUnique.mockResolvedValue({
+      intervalMinutes: 10,
+    });
+    mockPrisma.newsAnalysis.findFirst.mockResolvedValue(analysis);
+    mockAgentConfigResolver.resolveConfig.mockResolvedValue({
+      provider: 'CLAUDE',
+      model: 'claude-sonnet-4',
+    });
+    mockPrisma.lLMCredential.findUnique.mockResolvedValue(null);
+
+    await expect(service.analyzeSentiment('user1')).rejects.toThrow();
+
+    expect(mockAgentConfigResolver.resolveConfig).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/market/market-sentiment-ttl.spec.ts
+++ b/apps/api/src/market/market-sentiment-ttl.spec.ts
@@ -99,9 +99,7 @@ describe('MarketService.analyzeSentiment — TTL check (Spec 38, B.5)', () => {
       score: 60,
       overallSentiment: 'positive',
       summary: 'Test',
-      headlines: [
-        { id: '1', headline: 'Test news', sentiment: 'positive' },
-      ],
+      headlines: [{ id: '1', headline: 'Test news', sentiment: 'positive' }],
       aiAnalyzedAt: new Date(Date.now() - 20 * 60_000), // 20 min ago
       aiScore: 70,
     };

--- a/apps/api/src/market/market.service.ts
+++ b/apps/api/src/market/market.service.ts
@@ -287,8 +287,7 @@ export class MarketService {
     const ttlMs = ttlCfg.intervalMinutes * 60_000;
     const latestForTtl = await this.getLatestAnalysis(userId);
     if (latestForTtl?.aiAnalyzedAt) {
-      const age =
-        Date.now() - new Date(latestForTtl.aiAnalyzedAt).getTime();
+      const age = Date.now() - new Date(latestForTtl.aiAnalyzedAt).getTime();
       if (age < ttlMs) {
         this.logger.log(
           `AI analysis still fresh (${Math.round(age / 1000)}s < ${ttlCfg.intervalMinutes}min TTL). Skipping LLM call.`,
@@ -433,10 +432,9 @@ ${numbered}`;
     const aiHeadlines = headlines.map((h, i) => {
       const result = parsed.find((p) => p.index === i + 1);
       const rawSentiment = result?.sentiment?.toUpperCase?.() ?? '';
-      const sentiment =
-        validSentiments.has(rawSentiment)
-          ? (rawSentiment as 'POSITIVE' | 'NEGATIVE' | 'NEUTRAL')
-          : 'NEUTRAL';
+      const sentiment = validSentiments.has(rawSentiment)
+        ? (rawSentiment as 'POSITIVE' | 'NEGATIVE' | 'NEUTRAL')
+        : 'NEUTRAL';
       return { id: h.id, sentiment, reasoning: result?.reasoning ?? '' };
     });
 

--- a/apps/api/src/market/market.service.ts
+++ b/apps/api/src/market/market.service.ts
@@ -282,6 +282,21 @@ export class MarketService {
   // ── AI Sentiment Analysis → updates latest DB record ──────────────────────
 
   async analyzeSentiment(userId: string) {
+    // C1 TTL: Skip LLM call if AI analysis is still fresh (Spec 38, B.5)
+    const ttlCfg = await this.getNewsConfig(userId);
+    const ttlMs = ttlCfg.intervalMinutes * 60_000;
+    const latestForTtl = await this.getLatestAnalysis(userId);
+    if (latestForTtl?.aiAnalyzedAt) {
+      const age =
+        Date.now() - new Date(latestForTtl.aiAnalyzedAt).getTime();
+      if (age < ttlMs) {
+        this.logger.log(
+          `AI analysis still fresh (${Math.round(age / 1000)}s < ${ttlCfg.intervalMinutes}min TTL). Skipping LLM call.`,
+        );
+        return latestForTtl;
+      }
+    }
+
     // Resolve SIGMA agent config (market analysis agent)
     const agentCfg = await this.agentConfigResolver.resolveConfig(
       'market',

--- a/apps/api/src/market/market.service.ts
+++ b/apps/api/src/market/market.service.ts
@@ -279,26 +279,6 @@ export class MarketService {
     });
   }
 
-  // ── Resolve LLM for News (uses first active credential) ────────────────────
-
-  async resolveLLMForNews(
-    userId: string,
-  ): Promise<{ provider: LLMProvider; model: string; apiKey: string } | null> {
-    // Resolution now handled centrally by AgentConfigResolver for orchestrated calls.
-    // This method provides a simple fallback for direct news AI analysis.
-    const activeCreds = await this.prisma.lLMCredential.findMany({
-      where: { userId, isActive: true },
-    });
-    if (activeCreds.length === 0) return null;
-
-    const cred = activeCreds[0];
-    return {
-      provider: cred.provider as LLMProvider,
-      model: cred.selectedModel,
-      apiKey: decrypt(cred.apiKeyEncrypted, cred.apiKeyIv),
-    };
-  }
-
   // ── AI Sentiment Analysis → updates latest DB record ──────────────────────
 
   async analyzeSentiment(userId: string) {

--- a/apps/api/src/openrouter/openrouter-models-api.service.ts
+++ b/apps/api/src/openrouter/openrouter-models-api.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  OpenRouterModelsService,
+  OpenRouterModelInfo,
+  OpenRouterModelsFilter,
+} from '@crypto-trader/openrouter';
+
+@Injectable()
+export class OpenRouterModelsApiService {
+  private readonly logger = new Logger(OpenRouterModelsApiService.name);
+  private readonly modelsService: OpenRouterModelsService;
+
+  constructor() {
+    this.modelsService = new OpenRouterModelsService();
+  }
+
+  async getModels(
+    filter?: OpenRouterModelsFilter,
+  ): Promise<OpenRouterModelInfo[]> {
+    try {
+      return await this.modelsService.listModels(filter);
+    } catch (err) {
+      this.logger.warn(
+        `Failed to fetch OpenRouter models: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return [];
+    }
+  }
+
+  async getFreeModels(): Promise<OpenRouterModelInfo[]> {
+    return this.modelsService.getFreeModels();
+  }
+
+  async isModelAvailable(modelId: string): Promise<boolean> {
+    return this.modelsService.isModelAvailable(modelId);
+  }
+
+  invalidateCache(): void {
+    this.modelsService.invalidateCache();
+  }
+}

--- a/apps/api/src/openrouter/openrouter-models.controller.ts
+++ b/apps/api/src/openrouter/openrouter-models.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OpenRouterModelsApiService } from './openrouter-models-api.service';
+
+@Controller('openrouter')
+@UseGuards(JwtAuthGuard)
+export class OpenRouterModelsController {
+  constructor(private readonly modelsService: OpenRouterModelsApiService) {}
+
+  @Get('models')
+  async getModels(
+    @Query('category') category?: string,
+    @Query('freeOnly') freeOnly?: string,
+  ) {
+    const filter = {
+      category: category || undefined,
+      freeOnly: freeOnly === 'true',
+      textOnly: true,
+    };
+    const models = await this.modelsService.getModels(filter);
+    return { data: models, count: models.length };
+  }
+}

--- a/apps/api/src/openrouter/openrouter.module.ts
+++ b/apps/api/src/openrouter/openrouter.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { OpenRouterModelsApiService } from './openrouter-models-api.service';
+import { OpenRouterModelsController } from './openrouter-models.controller';
+
+@Module({
+  controllers: [OpenRouterModelsController],
+  providers: [OpenRouterModelsApiService],
+  exports: [OpenRouterModelsApiService],
+})
+export class OpenRouterModule {}

--- a/apps/api/src/orchestrator/dto/decision-synthesis.dto.ts
+++ b/apps/api/src/orchestrator/dto/decision-synthesis.dto.ts
@@ -22,4 +22,8 @@ export interface DecisionPayload {
   waitMinutes: number;
   orchestrated: boolean;
   subAgentResults: SubAgentResult[];
+  /** LLM provider used for the synthesis call */
+  llmProvider?: string;
+  /** LLM model used for the synthesis call */
+  llmModel?: string;
 }

--- a/apps/api/src/orchestrator/orchestrator.service.ts
+++ b/apps/api/src/orchestrator/orchestrator.service.ts
@@ -266,6 +266,17 @@ export class OrchestratorService {
     const forgeOutput = forgeRaw.status === 'fulfilled' ? forgeRaw.value : '{}';
     const aegisOutput = aegisRaw.status === 'fulfilled' ? aegisRaw.value : '{}';
 
+    // A2→DB: Persist fresh sentiment to NewsAnalysis (Spec 38, B.4)
+    if (sentimentRaw.status === 'fulfilled' && !cachedSentiment) {
+      try {
+        await this.persistSentimentAsAIAnalysis(userId, sentimentRaw.value);
+      } catch (err) {
+        this.logger.warn(
+          `Failed to persist sentiment A2→DB: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     subAgentResults.push(
       { agentId: 'market', task: 'technical_signal', output: techOutput },
       {
@@ -465,6 +476,63 @@ export class OrchestratorService {
       { responses, originalQuery, locale },
       userId,
       false,
+    );
+  }
+
+  /**
+   * A2→DB: Persist fresh SIGMA sentiment to NewsAnalysis (Spec 38).
+   * Updates the most recent NewsAnalysis for this user, or creates a minimal one.
+   */
+  private async persistSentimentAsAIAnalysis(
+    userId: string,
+    sentimentResult: string,
+  ): Promise<void> {
+    const parsed = safeParseJson<{
+      score?: number;
+      overallSentiment?: string;
+      summary?: string;
+      headlines?: { id: string; sentiment: string; reasoning?: string }[];
+    }>(sentimentResult, {});
+
+    if (!parsed.score && !parsed.overallSentiment) return;
+
+    const latest = await this.prisma.newsAnalysis.findFirst({
+      where: { userId },
+      orderBy: { analyzedAt: 'desc' },
+    });
+
+    const aiData = {
+      aiAnalyzedAt: new Date(),
+      aiScore: parsed.score ?? null,
+      aiOverallSentiment: parsed.overallSentiment ?? null,
+      aiSummary: parsed.summary ?? null,
+      aiHeadlines: (parsed.headlines as unknown) ?? undefined,
+    };
+
+    if (latest) {
+      await this.prisma.newsAnalysis.update({
+        where: { id: latest.id },
+        data: aiData,
+      });
+    } else {
+      await this.prisma.newsAnalysis.create({
+        data: {
+          userId,
+          newsCount: 0,
+          positiveCount: 0,
+          negativeCount: 0,
+          neutralCount: 0,
+          score: parsed.score ?? 50,
+          overallSentiment: parsed.overallSentiment ?? 'neutral',
+          summary: parsed.summary ?? 'AI analysis from trading orchestrator',
+          headlines: [],
+          ...aiData,
+        },
+      });
+    }
+
+    this.logger.log(
+      `A2→DB: Persisted SIGMA sentiment to NewsAnalysis for user=${userId}`,
     );
   }
 }

--- a/apps/api/src/orchestrator/orchestrator.service.ts
+++ b/apps/api/src/orchestrator/orchestrator.service.ts
@@ -323,6 +323,22 @@ export class OrchestratorService {
 
     // Synthesis call via orchestrator
     let synthesisRaw: string;
+    let synthesisProvider: string | undefined;
+    let synthesisModel: string | undefined;
+
+    // Resolve model info before the synthesis call
+    try {
+      const resolved = await this.subAgent.getProvider(
+        userId,
+        'synthesis',
+        typedOverride,
+      );
+      synthesisProvider = resolved.provider;
+      synthesisModel = resolved.model;
+    } catch {
+      // Non-blocking — we'll still attempt the call
+    }
+
     try {
       synthesisRaw = await this.subAgent.call(
         'orchestrator',
@@ -394,6 +410,8 @@ export class OrchestratorService {
         typeof synthesis.waitMinutes === 'number' ? synthesis.waitMinutes : 15,
       orchestrated: true,
       subAgentResults,
+      llmProvider: synthesisProvider,
+      llmModel: synthesisModel,
     };
   }
 
@@ -487,14 +505,31 @@ export class OrchestratorService {
     userId: string,
     sentimentResult: string,
   ): Promise<void> {
+    // SIGMA returns: { sentiment: number, impact: "positive|negative|neutral", reasoning: string }
+    // We also accept the alternate format: { score, overallSentiment, summary, headlines }
     const parsed = safeParseJson<{
+      sentiment?: number;
+      impact?: string;
+      reasoning?: string;
       score?: number;
       overallSentiment?: string;
       summary?: string;
       headlines?: { id: string; sentiment: string; reasoning?: string }[];
     }>(sentimentResult, {});
 
-    if (!parsed.score && !parsed.overallSentiment) return;
+    // Map SIGMA fields to NewsAnalysis AI fields
+    // SIGMA returns sentiment as float (-1 to 1) or integer (-100 to 100)
+    let aiScore: number | null = parsed.score ?? null;
+    if (aiScore == null && parsed.sentiment != null) {
+      aiScore =
+        Math.abs(parsed.sentiment) <= 1
+          ? Math.round(parsed.sentiment * 100)
+          : Math.round(parsed.sentiment);
+    }
+    const aiOverallSentiment = parsed.overallSentiment ?? parsed.impact ?? null;
+    const aiSummary = parsed.summary ?? parsed.reasoning ?? null;
+
+    if (aiScore == null && !aiOverallSentiment) return;
 
     const latest = await this.prisma.newsAnalysis.findFirst({
       where: { userId },
@@ -503,9 +538,9 @@ export class OrchestratorService {
 
     const aiData = {
       aiAnalyzedAt: new Date(),
-      aiScore: parsed.score ?? null,
-      aiOverallSentiment: parsed.overallSentiment ?? null,
-      aiSummary: parsed.summary ?? null,
+      aiScore,
+      aiOverallSentiment,
+      aiSummary,
       aiHeadlines: (parsed.headlines as unknown) ?? undefined,
     };
 
@@ -522,9 +557,9 @@ export class OrchestratorService {
           positiveCount: 0,
           negativeCount: 0,
           neutralCount: 0,
-          score: parsed.score ?? 50,
-          overallSentiment: parsed.overallSentiment ?? 'neutral',
-          summary: parsed.summary ?? 'AI analysis from trading orchestrator',
+          score: aiScore ?? 50,
+          overallSentiment: aiOverallSentiment ?? 'neutral',
+          summary: aiSummary ?? 'AI analysis from trading orchestrator',
           headlines: [],
           ...aiData,
         },
@@ -532,7 +567,7 @@ export class OrchestratorService {
     }
 
     this.logger.log(
-      `A2→DB: Persisted SIGMA sentiment to NewsAnalysis for user=${userId}`,
+      `A2→DB: Persisted SIGMA sentiment to NewsAnalysis for user=${userId} (score=${aiScore}, sentiment=${aiOverallSentiment})`,
     );
   }
 }

--- a/apps/api/src/orchestrator/sub-agent-provider-guard.spec.ts
+++ b/apps/api/src/orchestrator/sub-agent-provider-guard.spec.ts
@@ -1,0 +1,163 @@
+import { ConflictException } from '@nestjs/common';
+
+jest.mock('../../generated/prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock('@prisma/adapter-pg', () => ({ PrismaPg: jest.fn() }));
+jest.mock('../users/utils/encryption.util', () => ({
+  decrypt: jest.fn().mockReturnValue('fake-api-key'),
+  encrypt: jest.fn().mockReturnValue({ encrypted: 'enc', iv: 'iv' }),
+}));
+jest.mock('../../generated/prisma/enums', () => ({
+  LLMProvider: {
+    CLAUDE: 'CLAUDE',
+    OPENAI: 'OPENAI',
+    GROQ: 'GROQ',
+    GEMINI: 'GEMINI',
+    MISTRAL: 'MISTRAL',
+    TOGETHER: 'TOGETHER',
+    OPENROUTER: 'OPENROUTER',
+  },
+  AgentId: {
+    platform: 'platform',
+    operations: 'operations',
+    market: 'market',
+    blockchain: 'blockchain',
+    risk: 'risk',
+    orchestrator: 'orchestrator',
+    routing: 'routing',
+    synthesis: 'synthesis',
+  },
+  LLMSource: { ORCHESTRATOR: 'ORCHESTRATOR', CHAT: 'CHAT', MANUAL: 'MANUAL' },
+}));
+
+import { SubAgentService } from './sub-agent.service';
+
+const LLMProvider = {
+  CLAUDE: 'CLAUDE' as any,
+  OPENAI: 'OPENAI' as any,
+  OPENROUTER: 'OPENROUTER' as any,
+};
+
+const mockPrisma = {
+  lLMCredential: {
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+  },
+};
+
+const mockPlatformLLMProviderService = {
+  assertProviderActive: jest.fn(),
+};
+
+const mockAgentConfigResolver = {
+  resolveConfig: jest.fn(),
+};
+
+describe('SubAgentService.getProvider — provider guard (Spec 38)', () => {
+  let service: SubAgentService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new SubAgentService(
+      mockPrisma as any,
+      undefined, // ragService
+      undefined, // llmUsageService
+      mockAgentConfigResolver as any,
+      mockPlatformLLMProviderService as any,
+    );
+  });
+
+  it('should call assertProviderActive when override provider is used', async () => {
+    const cred = {
+      apiKeyEncrypted: Buffer.from('test').toString('hex'),
+      apiKeyIv: Buffer.from('1234567890123456').toString('hex'),
+      provider: LLMProvider.CLAUDE,
+      selectedModel: 'claude-sonnet-4',
+      fallbackModels: [],
+    };
+    mockPrisma.lLMCredential.findFirst.mockResolvedValue(cred);
+    mockPlatformLLMProviderService.assertProviderActive.mockResolvedValue(
+      undefined,
+    );
+
+    await service.getProvider('user1', 'market', {
+      provider: LLMProvider.CLAUDE,
+      model: 'claude-sonnet-4',
+    });
+
+    expect(
+      mockPlatformLLMProviderService.assertProviderActive,
+    ).toHaveBeenCalledWith(LLMProvider.CLAUDE);
+  });
+
+  it('should throw ConflictException when override provider is disabled', async () => {
+    const cred = {
+      apiKeyEncrypted: Buffer.from('test').toString('hex'),
+      apiKeyIv: Buffer.from('1234567890123456').toString('hex'),
+      provider: LLMProvider.OPENAI,
+      selectedModel: 'gpt-4o',
+      fallbackModels: [],
+    };
+    mockPrisma.lLMCredential.findFirst.mockResolvedValue(cred);
+    mockPlatformLLMProviderService.assertProviderActive.mockRejectedValue(
+      new ConflictException('Provider OPENAI is disabled'),
+    );
+
+    await expect(
+      service.getProvider('user1', 'market', {
+        provider: LLMProvider.OPENAI,
+        model: 'gpt-4o',
+      }),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('should call assertProviderActive for AgentConfigResolver resolved provider', async () => {
+    mockPrisma.lLMCredential.findFirst.mockResolvedValueOnce({
+      // resolver branch
+      apiKeyEncrypted: Buffer.from('test').toString('hex'),
+      apiKeyIv: Buffer.from('1234567890123456').toString('hex'),
+      provider: LLMProvider.CLAUDE,
+      selectedModel: 'claude-sonnet-4',
+      fallbackModels: [],
+    });
+    mockAgentConfigResolver.resolveConfig.mockResolvedValue({
+      provider: LLMProvider.CLAUDE,
+      model: 'claude-sonnet-4',
+    });
+    mockPlatformLLMProviderService.assertProviderActive.mockResolvedValue(
+      undefined,
+    );
+
+    await service.getProvider('user1', 'market');
+
+    expect(
+      mockPlatformLLMProviderService.assertProviderActive,
+    ).toHaveBeenCalledWith(LLMProvider.CLAUDE);
+  });
+
+  it('should call assertProviderActive for fallback provider', async () => {
+    mockPrisma.lLMCredential.findFirst.mockResolvedValue(null);
+    mockAgentConfigResolver.resolveConfig.mockRejectedValue(
+      new Error('No config'),
+    );
+    mockPrisma.lLMCredential.findMany.mockResolvedValue([
+      {
+        apiKeyEncrypted: Buffer.from('test').toString('hex'),
+        apiKeyIv: Buffer.from('1234567890123456').toString('hex'),
+        provider: LLMProvider.OPENROUTER,
+        selectedModel: 'meta-llama/llama-3',
+        fallbackModels: [],
+      },
+    ]);
+    mockPlatformLLMProviderService.assertProviderActive.mockResolvedValue(
+      undefined,
+    );
+
+    await service.getProvider('user1', 'market');
+
+    expect(
+      mockPlatformLLMProviderService.assertProviderActive,
+    ).toHaveBeenCalledWith(LLMProvider.OPENROUTER);
+  });
+});

--- a/apps/api/src/orchestrator/sub-agent.service.ts
+++ b/apps/api/src/orchestrator/sub-agent.service.ts
@@ -14,6 +14,7 @@ import { LLMUsageService } from '../llm/llm-usage.service';
 import { recordCall } from '../llm/provider-health.service';
 import { LLMSource } from '../../generated/prisma/enums';
 import { AgentConfigResolverService } from '../agents/agent-config-resolver.service';
+import { PlatformLLMProviderService } from '../llm/platform-llm-provider.service';
 
 export type SubAgentId =
   | 'platform'
@@ -415,6 +416,8 @@ export class SubAgentService {
     @Optional() private readonly llmUsageService?: LLMUsageService,
     @Optional()
     private readonly agentConfigResolver?: AgentConfigResolverService,
+    @Optional()
+    private readonly platformLLMProviderService?: PlatformLLMProviderService,
   ) {}
 
   /**
@@ -560,12 +563,20 @@ export class SubAgentService {
     provider: LLMProvider;
     model: string;
   }> {
+    // Helper: validate resolved provider is active at platform level (Spec 38, Fix P4)
+    const assertActive = async (provider: LLMProvider) => {
+      if (this.platformLLMProviderService) {
+        await this.platformLLMProviderService.assertProviderActive(provider);
+      }
+    };
+
     // 1. Explicit override
     if (override) {
       const cred = await this.prisma.lLMCredential.findFirst({
         where: { userId, provider: override.provider as any, isActive: true },
       });
       if (cred) {
+        await assertActive(override.provider);
         const apiKey = decrypt(cred.apiKeyEncrypted, cred.apiKeyIv);
         const client =
           override.provider === LLMProvider.OPENROUTER
@@ -594,6 +605,7 @@ export class SubAgentService {
           where: { userId, provider: resolved.provider as any, isActive: true },
         });
         if (cred) {
+          await assertActive(resolved.provider as unknown as LLMProvider);
           const apiKey = decrypt(cred.apiKeyEncrypted, cred.apiKeyIv);
           const client =
             resolved.provider === (LLMProvider.OPENROUTER as any)
@@ -627,8 +639,9 @@ export class SubAgentService {
 
     if (allCreds.length > 0) {
       const cred = allCreds[0];
-      const apiKey = decrypt(cred.apiKeyEncrypted, cred.apiKeyIv);
       const credProvider = cred.provider as LLMProvider;
+      await assertActive(credProvider);
+      const apiKey = decrypt(cred.apiKeyEncrypted, cred.apiKeyIv);
       const client =
         credProvider === LLMProvider.OPENROUTER
           ? new OpenRouterProvider({

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -82,6 +82,9 @@ export class PrismaService implements OnModuleInit, OnModuleDestroy {
   get adminAgentConfig() {
     return this._client.adminAgentConfig;
   }
+  get platformLLMProvider() {
+    return this._client.platformLLMProvider;
+  }
 
   $queryRaw<T = unknown>(
     ...args: Parameters<PrismaClientInstance['$queryRaw']>

--- a/apps/api/src/trading/trading.module.ts
+++ b/apps/api/src/trading/trading.module.ts
@@ -9,6 +9,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { UsersModule } from '../users/users.module';
 import { MarketModule } from '../market/market.module';
 import { OrchestratorModule } from '../orchestrator/orchestrator.module';
+import { AgentConfigModule } from '../agents/agent-config.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { OrchestratorModule } from '../orchestrator/orchestrator.module';
     UsersModule,
     MarketModule,
     OrchestratorModule,
+    AgentConfigModule,
   ],
   controllers: [TradingController],
   providers: [TradingService, TradingProcessor],

--- a/apps/api/src/trading/trading.processor.ts
+++ b/apps/api/src/trading/trading.processor.ts
@@ -167,9 +167,8 @@ export class TradingProcessor {
       // 5. Build indicator snapshot
       const indicatorSnapshot = calculateIndicatorSnapshot(candles);
 
-      // 6. Load news analysis from DB (AI if within 12h, else keyword-based)
+      // 6. Load news analysis from DB (AI if available, else keyword-based)
       //    Respects botEnabled: if disabled, bot runs without news context
-      const AI_VALID_MS = 12 * 60 * 60 * 1000;
       const newsConfig = await this.marketService.getNewsConfig(userId);
       const dbAnalysis = newsConfig.botEnabled
         ? await this.marketService.getLatestAnalysis(userId)
@@ -186,12 +185,7 @@ export class TradingProcessor {
       }> = [];
 
       if (dbAnalysis) {
-        const hasRecentAI =
-          dbAnalysis.aiAnalyzedAt &&
-          Date.now() - new Date(dbAnalysis.aiAnalyzedAt).getTime() <
-            AI_VALID_MS;
-
-        if (hasRecentAI && dbAnalysis.aiHeadlines) {
+        if (dbAnalysis.aiAnalyzedAt && dbAnalysis.aiHeadlines) {
           // Merge AI overrides into headlines
           const aiMap = new Map(
             (
@@ -288,6 +282,8 @@ export class TradingProcessor {
         suggestedWaitMinutes: orchestratedDecision.waitMinutes,
         orchestrated: orchestratedDecision.orchestrated,
         subAgentResults: orchestratedDecision.subAgentResults,
+        llmProvider: orchestratedDecision.llmProvider,
+        llmModel: orchestratedDecision.llmModel,
       };
 
       // Compute effective wait: AGENT mode respects LLM suggestion, CUSTOM mode uses user config.
@@ -320,6 +316,8 @@ export class TradingProcessor {
           metadata: {
             orchestrated: decision.orchestrated,
             subAgentResults: decision.subAgentResults,
+            llmProvider: decision.llmProvider ?? null,
+            llmModel: decision.llmModel ?? null,
           } as any,
         },
       });

--- a/apps/api/src/trading/trading.processor.ts
+++ b/apps/api/src/trading/trading.processor.ts
@@ -8,6 +8,7 @@ import { UsersService } from '../users/users.service';
 import { TRADING_QUEUE } from './trading.service';
 import { MarketService } from '../market/market.service';
 import { OrchestratorService } from '../orchestrator/orchestrator.service';
+import { AgentConfigResolverService } from '../agents/agent-config-resolver.service';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { BinanceRestClient } from '@crypto-trader/data-fetcher';
@@ -28,6 +29,7 @@ import {
 } from '@crypto-trader/shared';
 import { SUPPORTED_PAIRS, TRADE_FEE_PCT } from '@crypto-trader/shared';
 import { decrypt } from '../users/utils/encryption.util';
+import type { AgentHealthReport } from '../agents/agent-config-resolver.service';
 
 interface AgentJobData {
   userId: string;
@@ -46,6 +48,7 @@ export class TradingProcessor {
     private readonly usersService: UsersService,
     private readonly marketService: MarketService,
     private readonly orchestratorService: OrchestratorService,
+    private readonly agentConfigResolver: AgentConfigResolverService,
   ) {}
 
   @Process('run-cycle')
@@ -117,14 +120,16 @@ export class TradingProcessor {
         );
       }
 
-      // 3. Decrypt LLM credentials
-      const llmCred = await this.prisma.lLMCredential.findFirst({
-        where: { userId, isActive: true },
-        orderBy: { createdAt: 'desc' },
-      });
-      if (!llmCred) {
+      // 3. Verify LLM health — agent-aware check (Spec 38, Fix P2)
+      const healthReport: AgentHealthReport =
+        await this.agentConfigResolver.checkHealth(userId);
+      if (!healthReport.healthy) {
+        const unhealthy = healthReport.agents
+          .filter((a) => !a.healthy)
+          .map((a) => a.agentId)
+          .join(', ');
         this.logger.warn(
-          `No LLM credentials for user ${userId} — pausing agent`,
+          `Agent config health check failed for user ${userId} — unhealthy agents: ${unhealthy} — pausing`,
         );
         await this.prisma.tradingConfig.update({
           where: { id: configId },
@@ -137,7 +142,6 @@ export class TradingProcessor {
         );
         return;
       }
-      const llmApiKey = decrypt(llmCred.apiKeyEncrypted, llmCred.apiKeyIv);
 
       // 4. Fetch candles
       // Klines is a PUBLIC endpoint — no auth or testnet URL needed.

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -2,6 +2,12 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { PlatformLLMProviderService } from '../llm/platform-llm-provider.service';
+
+const mockPlatformLLMProviderService = {
+  assertProviderActive: jest.fn().mockResolvedValue(undefined),
+  isProviderActive: jest.fn().mockResolvedValue(true),
+};
 
 const mockPrismaService = {
   user: {
@@ -36,6 +42,10 @@ describe('UsersService', () => {
       providers: [
         UsersService,
         { provide: PrismaService, useValue: mockPrismaService },
+        {
+          provide: PlatformLLMProviderService,
+          useValue: mockPlatformLLMProviderService,
+        },
       ],
     }).compile();
 

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -20,10 +20,14 @@ import { encrypt, decrypt } from './utils/encryption.util';
 import { LLMProvider, NewsApiProvider } from '../../generated/prisma/enums';
 import { BinanceRestClient } from '@crypto-trader/data-fetcher';
 import { recordCall } from '../llm/provider-health.service';
+import { PlatformLLMProviderService } from '../llm/platform-llm-provider.service';
 
 @Injectable()
 export class UsersService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly platformLLMProviderService: PlatformLLMProviderService,
+  ) {}
 
   // ── Profile ────────────────────────────────────────────────────────────────
 
@@ -208,6 +212,10 @@ export class UsersService {
 
   async setLLMKey(userId: string, dto: LLMKeyDto) {
     const provider = dto.provider as LLMProvider;
+
+    // Validate provider is active at platform level (Spec 38)
+    await this.platformLLMProviderService.assertProviderActive(provider);
+
     const { encrypted: apiKeyEncrypted, iv: apiKeyIv } = encrypt(dto.apiKey);
 
     return this.prisma.lLMCredential.upsert({

--- a/apps/web/src/components/bot-analysis/agent-countdown-card.tsx
+++ b/apps/web/src/components/bot-analysis/agent-countdown-card.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import { Bot, Activity, Timer } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
@@ -28,7 +28,14 @@ export function AgentCountdownCard({
   }, [serverNextRunAt, lastDecision, config.minIntervalMinutes]);
 
   const countdown = useCountdown(nextCycleAt);
-  const isPast = nextCycleAt !== null && nextCycleAt <= Date.now();
+
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const isPast = nextCycleAt !== null && nextCycleAt <= now;
   const progress = useMemo(() => {
     if (!nextCycleAt) return 0;
     if (serverNextRunAt) {
@@ -37,15 +44,21 @@ export function AgentCountdownCard({
         : nextCycleAt - 15 * 60_000;
       const total = nextCycleAt - start;
       if (total <= 0) return 100;
-      const elapsed = Date.now() - start;
+      const elapsed = now - start;
       return Math.min(100, Math.max(0, Math.round((elapsed / total) * 100)));
     }
     if (!lastDecision) return 0;
     const wait =
       (lastDecision.waitMinutes ?? config.minIntervalMinutes ?? 30) * 60_000;
-    const elapsed = Date.now() - new Date(lastDecision.createdAt).getTime();
+    const elapsed = now - new Date(lastDecision.createdAt).getTime();
     return Math.min(100, Math.round((elapsed / wait) * 100));
-  }, [nextCycleAt, serverNextRunAt, lastDecision, config.minIntervalMinutes]);
+  }, [
+    nextCycleAt,
+    serverNextRunAt,
+    lastDecision,
+    config.minIntervalMinutes,
+    now,
+  ]);
 
   const [showStateModal, setShowStateModal] = useState(false);
 

--- a/apps/web/src/components/bot-analysis/constants.ts
+++ b/apps/web/src/components/bot-analysis/constants.ts
@@ -34,8 +34,6 @@ export const SENTIMENT_COLOR: Record<string, string> = {
   NEUTRAL: 'text-muted-foreground',
 };
 
-export const AI_VALID_MS = 12 * 60 * 60 * 1000;
-
 export type StateModalTab = 'estado' | 'indicadores' | 'noticias' | 'config';
 
 export const STATE_MODAL_TABS: {

--- a/apps/web/src/components/bot-analysis/news-sentiment-panel.tsx
+++ b/apps/web/src/components/bot-analysis/news-sentiment-panel.tsx
@@ -17,7 +17,7 @@ import {
   useNewsAnalysis,
   type NewsItem,
 } from '../../hooks/use-market';
-import { SENTIMENT_COLOR, AI_VALID_MS } from './constants';
+import { SENTIMENT_COLOR } from './constants';
 
 export interface SigmaSentiment {
   sentiment: number;
@@ -37,10 +37,23 @@ export function NewsSentimentPanel({
   const { data: config } = useNewsConfig();
   const { data: analysis } = useNewsAnalysis();
 
-  const hasAi = !!(
-    analysis?.aiAnalyzedAt &&
-    Date.now() - new Date(analysis.aiAnalyzedAt).getTime() < AI_VALID_MS
-  );
+  const hasAi = !!analysis?.aiAnalyzedAt;
+
+  // Derive SIGMA from AI analysis when available; fall back to agent decision sigma
+  const effectiveSigma: SigmaSentiment | null = hasAi
+    ? {
+        sentiment: analysis?.aiScore ?? 0,
+        impact:
+          analysis?.aiOverallSentiment === 'POSITIVE' ||
+          analysis?.aiOverallSentiment === 'BULLISH'
+            ? 'positive'
+            : analysis?.aiOverallSentiment === 'NEGATIVE' ||
+                analysis?.aiOverallSentiment === 'BEARISH'
+              ? 'negative'
+              : 'neutral',
+        reasoning: analysis?.aiSummary ?? '',
+      }
+    : (sigmaSentiment ?? null);
 
   const positive = hasAi
     ? (analysis?.aiPositiveCount ?? 0)
@@ -115,10 +128,8 @@ export function NewsSentimentPanel({
         <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {t('botAnalysis.newsSentimentTitle')}
         </span>
-        {sigmaSentiment ? (
-          <span
-            className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold border bg-violet-500/10 text-violet-400 border-violet-500/20"
-          >
+        {effectiveSigma ? (
+          <span className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold border bg-violet-500/10 text-violet-400 border-violet-500/20">
             <Brain className="h-2.5 w-2.5" /> SIGMA
           </span>
         ) : analysis ? (
@@ -264,13 +275,13 @@ export function NewsSentimentPanel({
         )}
 
         {/* SIGMA AI Conclusion */}
-        {sigmaSentiment && (
+        {effectiveSigma && (
           <div
             className={cn(
               'shrink-0 rounded-lg border p-3 space-y-1.5',
-              sigmaSentiment.impact === 'positive'
+              effectiveSigma.impact === 'positive'
                 ? 'border-emerald-500/20 bg-emerald-500/[0.06]'
-                : sigmaSentiment.impact === 'negative'
+                : effectiveSigma.impact === 'negative'
                   ? 'border-red-500/20 bg-red-500/[0.06]'
                   : 'border-amber-500/20 bg-amber-500/[0.06]',
             )}
@@ -283,20 +294,20 @@ export function NewsSentimentPanel({
               <span
                 className={cn(
                   'ml-1 text-[10px] font-semibold',
-                  sigmaSentiment.impact === 'positive'
+                  effectiveSigma.impact === 'positive'
                     ? 'text-emerald-400'
-                    : sigmaSentiment.impact === 'negative'
+                    : effectiveSigma.impact === 'negative'
                       ? 'text-red-400'
                       : 'text-amber-400',
                 )}
               >
-                {sigmaSentiment.impact === 'positive'
+                {effectiveSigma.impact === 'positive'
                   ? t('botAnalysis.sigmaImpactPositive')
-                  : sigmaSentiment.impact === 'negative'
+                  : effectiveSigma.impact === 'negative'
                     ? t('botAnalysis.sigmaImpactNegative')
                     : t('botAnalysis.sigmaImpactNeutral')}
               </span>
-              {sigmaSentiment.cached && (
+              {effectiveSigma.cached && (
                 <span className="ml-auto inline-flex items-center gap-0.5 text-[9px] text-muted-foreground/60">
                   <RefreshCw className="h-2.5 w-2.5" />
                   {t('botAnalysis.sigmaCached')}
@@ -304,24 +315,24 @@ export function NewsSentimentPanel({
               )}
             </div>
             <p className="text-[11px] leading-relaxed text-foreground/80">
-              {sigmaSentiment.reasoning}
+              {effectiveSigma.reasoning}
             </p>
             <div className="text-right">
               <span
                 className={cn(
                   'text-[10px] font-mono font-bold',
-                  sigmaSentiment.sentiment > 0
+                  effectiveSigma.sentiment > 0
                     ? 'text-emerald-400'
-                    : sigmaSentiment.sentiment < 0
+                    : effectiveSigma.sentiment < 0
                       ? 'text-red-400'
                       : 'text-amber-400',
                 )}
               >
                 {t('botAnalysis.scoreLabel')}:{' '}
-                {sigmaSentiment.sentiment > 0 ? '+' : ''}
-                {typeof sigmaSentiment.sentiment === 'number'
-                  ? sigmaSentiment.sentiment.toFixed(2)
-                  : sigmaSentiment.sentiment}
+                {effectiveSigma.sentiment > 0 ? '+' : ''}
+                {typeof effectiveSigma.sentiment === 'number'
+                  ? effectiveSigma.sentiment.toFixed(2)
+                  : effectiveSigma.sentiment}
               </span>
             </div>
           </div>

--- a/apps/web/src/components/config/constants.tsx
+++ b/apps/web/src/components/config/constants.tsx
@@ -67,16 +67,7 @@ export const LLM_PROVIDERS: LLMProviderOption[] = [
   {
     value: 'OPENROUTER',
     label: 'OpenRouter',
-    models: [
-      'anthropic/claude-sonnet-4.6',
-      'google/gemini-3-flash-preview',
-      'anthropic/claude-opus-4.6',
-      'deepseek/deepseek-v3.2',
-      'google/gemini-2.5-flash-lite',
-      'openrouter/elephant-alpha',
-      'nvidia/nemotron-3-super-120b-a12b:free',
-      'google/gemma-4-31b-it:free',
-    ],
+    models: [], // Resolved dynamically via useOpenRouterModels hook
   },
 ];
 

--- a/apps/web/src/components/news-feed/analysis-summary-card.tsx
+++ b/apps/web/src/components/news-feed/analysis-summary-card.tsx
@@ -8,7 +8,6 @@ import {
   RefreshCw,
   XCircle,
   Hash,
-  Zap,
   Settings,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +16,7 @@ import { type NewsAnalysis } from '../../hooks/use-market';
 import { timeAgo, SENTIMENT_CONFIG } from './news-utils';
 import type { SigmaSentiment } from '../bot-analysis';
 
-type AnalysisTab = 'sigma' | 'keyword';
+type AnalysisTab = 'ai' | 'keyword';
 
 export function AnalysisSummaryCard({
   analysis,
@@ -39,12 +38,31 @@ export function AnalysisSummaryCard({
   sigmaTimestamp?: string | null;
 }) {
   const { t } = useTranslation();
-  const hasSigma = !!sigmaSentiment;
+  const hasAi = !!analysis?.aiAnalyzedAt;
+
+  // Derive effective SIGMA from AI analysis when available; fall back to agent decision sigma
+  const effectiveSigma: SigmaSentiment | null = hasAi
+    ? {
+        sentiment: analysis?.aiScore ?? 0,
+        impact:
+          analysis?.aiOverallSentiment === 'POSITIVE' ||
+          analysis?.aiOverallSentiment === 'BULLISH'
+            ? 'positive'
+            : analysis?.aiOverallSentiment === 'NEGATIVE' ||
+                analysis?.aiOverallSentiment === 'BEARISH'
+              ? 'negative'
+              : 'neutral',
+        reasoning: analysis?.aiSummary ?? '',
+      }
+    : (sigmaSentiment ?? null);
+
+  const hasSigma = !!effectiveSigma;
+  const hasAnyAi = hasSigma || hasAi;
 
   const [activeTab, setActiveTab] = useState<AnalysisTab>(
-    hasSigma ? 'sigma' : 'keyword',
+    hasAnyAi ? 'ai' : 'keyword',
   );
-  const effectiveTab = hasSigma ? activeTab : 'keyword';
+  const effectiveTab = hasAnyAi ? activeTab : 'keyword';
 
   // Keyword data
   const kwPositive = analysis?.positiveCount ?? 0;
@@ -54,9 +72,25 @@ export function AnalysisSummaryCard({
   const kwScore = analysis?.score ?? 0;
   const kwOverall = analysis?.overallSentiment ?? 'NEUTRAL';
 
-  // SIGMA overall
-  const sigmaImpact = sigmaSentiment?.impact ?? 'neutral';
-  const sigmaScore = sigmaSentiment?.sentiment ?? 0;
+  // AI data (from manual AI analysis or A2→DB)
+  const aiPositive = analysis?.aiPositiveCount ?? 0;
+  const aiNegative = analysis?.aiNegativeCount ?? 0;
+  const aiNeutral = analysis?.aiNeutralCount ?? 0;
+  const aiTotal = aiPositive + aiNegative + aiNeutral;
+  const aiScore = analysis?.aiScore ?? 0;
+  const rawAiOverall = (
+    analysis?.aiOverallSentiment ?? 'NEUTRAL'
+  ).toUpperCase();
+  const aiOverall =
+    rawAiOverall === 'POSITIVE' || rawAiOverall === 'BULLISH'
+      ? 'BULLISH'
+      : rawAiOverall === 'NEGATIVE' || rawAiOverall === 'BEARISH'
+        ? 'BEARISH'
+        : 'NEUTRAL';
+
+  // SIGMA overall (used within the AI tab)
+  const sigmaImpact = effectiveSigma?.impact ?? 'neutral';
+  const sigmaScore = effectiveSigma?.sentiment ?? 0;
   const sigmaOverall =
     sigmaImpact === 'positive'
       ? 'BULLISH'
@@ -64,7 +98,10 @@ export function AnalysisSummaryCard({
         ? 'BEARISH'
         : 'NEUTRAL';
 
-  const displayOverall = effectiveTab === 'sigma' ? sigmaOverall : kwOverall;
+  // For the AI tab, prefer SIGMA overall if available, else AI overall
+  const aiTabOverall = hasSigma ? sigmaOverall : aiOverall;
+
+  const displayOverall = effectiveTab === 'ai' ? aiTabOverall : kwOverall;
 
   const overallColor =
     displayOverall === 'BULLISH'
@@ -95,10 +132,10 @@ export function AnalysisSummaryCard({
         <span className="text-sm font-semibold">
           {t('news.sentimentSummary')}
         </span>
-        {effectiveTab === 'sigma' && hasSigma && (
-          <span className="flex items-center gap-1 rounded-full bg-violet-500/10 border border-violet-500/20 px-2 py-0.5 text-[11px] font-semibold text-violet-400">
-            <Zap className="h-3 w-3" />
-            SIGMA
+        {effectiveTab === 'ai' && hasAnyAi && (
+          <span className="flex items-center gap-1 rounded-full bg-primary/10 border border-primary/20 px-2 py-0.5 text-[11px] font-semibold text-primary">
+            <Sparkles className="h-3 w-3" />
+            IA
           </span>
         )}
         <span
@@ -117,24 +154,24 @@ export function AnalysisSummaryCard({
       </div>
 
       <div className="p-5 space-y-4">
-        {/* Tabs: SIGMA | Keyword */}
-        {(hasSigma || analysis) && (
+        {/* Tabs: IA | Keyword */}
+        {(hasAnyAi || analysis) && (
           <div className="flex gap-1 rounded-lg border border-border bg-muted/20 p-0.5 w-fit">
-            {hasSigma && (
+            {hasAnyAi && (
               <button
-                onClick={() => setActiveTab('sigma')}
+                onClick={() => setActiveTab('ai')}
                 className={cn(
                   'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all',
-                  effectiveTab === 'sigma'
+                  effectiveTab === 'ai'
                     ? 'bg-background text-foreground shadow-sm'
                     : 'text-muted-foreground hover:text-foreground',
                 )}
               >
-                <Zap className="h-3 w-3 text-violet-400 shrink-0" />
-                {t('news.lastSigmaAnalysis')}
-                {sigmaTimestamp && (
+                <Sparkles className="h-3 w-3 text-primary shrink-0" />
+                {t('news.lastAiAnalysis')}
+                {(sigmaTimestamp || analysis?.aiAnalyzedAt) && (
                   <span className="text-[10px] text-muted-foreground/70 ml-1">
-                    {timeAgo(sigmaTimestamp)}
+                    {timeAgo(sigmaTimestamp ?? analysis!.aiAnalyzedAt!)}
                   </span>
                 )}
               </button>
@@ -159,71 +196,148 @@ export function AnalysisSummaryCard({
           </div>
         )}
 
-        {/* ── SIGMA Tab Content ── */}
-        {effectiveTab === 'sigma' && sigmaSentiment && (
+        {/* ── IA Tab Content (SIGMA + AI analysis combined) ── */}
+        {effectiveTab === 'ai' && hasAnyAi && (
           <>
-            <div
-              className={cn(
-                'rounded-lg border p-3 space-y-1.5',
-                sigmaSentiment.impact === 'positive'
-                  ? 'border-emerald-500/20 bg-emerald-500/[0.06]'
-                  : sigmaSentiment.impact === 'negative'
-                    ? 'border-red-500/20 bg-red-500/[0.06]'
-                    : 'border-amber-500/20 bg-amber-500/[0.06]',
-              )}
-            >
-              <div className="flex items-center gap-1.5">
-                <Brain className="h-3 w-3 text-violet-400" />
-                <span className="text-[10px] font-bold uppercase tracking-wide text-violet-400">
-                  {t('botAnalysis.sigmaTitle')}
-                </span>
-                <span
-                  className={cn(
-                    'ml-1 text-[10px] font-semibold',
-                    sigmaSentiment.impact === 'positive'
-                      ? 'text-emerald-400'
-                      : sigmaSentiment.impact === 'negative'
-                        ? 'text-red-400'
-                        : 'text-amber-400',
-                  )}
-                >
-                  {sigmaSentiment.impact === 'positive'
-                    ? t('botAnalysis.sigmaImpactPositive')
-                    : sigmaSentiment.impact === 'negative'
-                      ? t('botAnalysis.sigmaImpactNegative')
-                      : t('botAnalysis.sigmaImpactNeutral')}
-                </span>
-                {sigmaSentiment.cached && (
-                  <span className="ml-auto inline-flex items-center gap-0.5 text-[9px] text-muted-foreground/60">
-                    <RefreshCw className="h-2.5 w-2.5" />
-                    {t('botAnalysis.sigmaCached')}
+            {/* SIGMA insight block */}
+            {hasSigma && (
+              <div
+                className={cn(
+                  'rounded-lg border p-3 space-y-1.5',
+                  effectiveSigma.impact === 'positive'
+                    ? 'border-emerald-500/20 bg-emerald-500/[0.06]'
+                    : effectiveSigma.impact === 'negative'
+                      ? 'border-red-500/20 bg-red-500/[0.06]'
+                      : 'border-amber-500/20 bg-amber-500/[0.06]',
+                )}
+              >
+                <div className="flex items-center gap-1.5">
+                  <Brain className="h-3 w-3 text-violet-400" />
+                  <span className="text-[10px] font-bold uppercase tracking-wide text-violet-400">
+                    {t('botAnalysis.sigmaTitle')}
                   </span>
+                  <span
+                    className={cn(
+                      'ml-1 text-[10px] font-semibold',
+                      effectiveSigma.impact === 'positive'
+                        ? 'text-emerald-400'
+                        : effectiveSigma.impact === 'negative'
+                          ? 'text-red-400'
+                          : 'text-amber-400',
+                    )}
+                  >
+                    {effectiveSigma.impact === 'positive'
+                      ? t('botAnalysis.sigmaImpactPositive')
+                      : effectiveSigma.impact === 'negative'
+                        ? t('botAnalysis.sigmaImpactNegative')
+                        : t('botAnalysis.sigmaImpactNeutral')}
+                  </span>
+                  {effectiveSigma.cached && (
+                    <span className="ml-auto inline-flex items-center gap-0.5 text-[9px] text-muted-foreground/60">
+                      <RefreshCw className="h-2.5 w-2.5" />
+                      {t('botAnalysis.sigmaCached')}
+                    </span>
+                  )}
+                </div>
+                <p className="text-[11px] leading-relaxed text-foreground/80">
+                  {effectiveSigma.reasoning}
+                </p>
+                <div className="text-right">
+                  <span
+                    className={cn(
+                      'text-[10px] font-mono font-bold',
+                      sigmaScore > 0
+                        ? 'text-emerald-400'
+                        : sigmaScore < 0
+                          ? 'text-red-400'
+                          : 'text-amber-400',
+                    )}
+                  >
+                    Score: {sigmaScore > 0 ? '+' : ''}
+                    {typeof sigmaScore === 'number'
+                      ? sigmaScore.toFixed(2)
+                      : sigmaScore}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {/* AI headline counts (from manual AI or A2→DB) */}
+            {hasAi && aiTotal > 0 && (
+              <div>
+                <div className="flex items-center justify-between text-[11px] text-muted-foreground mb-2">
+                  <div className="flex items-center gap-1">
+                    <TrendingUp className="h-3 w-3 text-emerald-400" />
+                    <span className="font-semibold text-emerald-400">
+                      {t('news.positiveCount', { count: aiPositive })}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Minus className="h-3 w-3 text-amber-400" />
+                    <span className="text-amber-400">
+                      {t('news.neutralCount', { count: aiNeutral })}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <TrendingDown className="h-3 w-3 text-red-400" />
+                    <span className="font-semibold text-red-400">
+                      {t('news.negativeCount', { count: aiNegative })}
+                    </span>
+                  </div>
+                </div>
+                <div className="h-3 rounded-full bg-muted overflow-hidden flex">
+                  {aiPositive > 0 && (
+                    <div
+                      className="h-full bg-emerald-500 transition-all duration-700"
+                      style={{
+                        width: `${aiTotal ? (aiPositive / aiTotal) * 100 : 0}%`,
+                      }}
+                    />
+                  )}
+                  {aiNeutral > 0 && (
+                    <div
+                      className="h-full bg-amber-500/50 transition-all duration-700"
+                      style={{
+                        width: `${aiTotal ? (aiNeutral / aiTotal) * 100 : 0}%`,
+                      }}
+                    />
+                  )}
+                  {aiNegative > 0 && (
+                    <div
+                      className="h-full bg-red-500 transition-all duration-700"
+                      style={{
+                        width: `${aiTotal ? (aiNegative / aiTotal) * 100 : 0}%`,
+                      }}
+                    />
+                  )}
+                </div>
+                <div className="flex items-center justify-between mt-1.5 text-[11px]">
+                  <span className="text-muted-foreground">
+                    {t('news.newsAnalyzed', { count: aiTotal })}
+                  </span>
+                  <span
+                    className={cn(
+                      'font-bold',
+                      aiOverall === 'BULLISH'
+                        ? 'text-emerald-400'
+                        : aiOverall === 'BEARISH'
+                          ? 'text-red-400'
+                          : 'text-amber-400',
+                    )}
+                  >
+                    Score: {aiScore > 0 ? '+' : ''}
+                    {aiScore}
+                  </span>
+                </div>
+                {analysis?.aiSummary && (
+                  <p className="mt-2 text-[11px] text-muted-foreground/70 leading-relaxed">
+                    {analysis.aiSummary}
+                  </p>
                 )}
               </div>
-              <p className="text-[11px] leading-relaxed text-foreground/80">
-                {sigmaSentiment.reasoning}
-              </p>
-              <div className="text-right">
-                <span
-                  className={cn(
-                    'text-[10px] font-mono font-bold',
-                    sigmaScore > 0
-                      ? 'text-emerald-400'
-                      : sigmaScore < 0
-                        ? 'text-red-400'
-                        : 'text-amber-400',
-                  )}
-                >
-                  Score:{' '}
-                  {sigmaScore > 0 ? '+' : ''}
-                  {typeof sigmaScore === 'number'
-                    ? sigmaScore.toFixed(2)
-                    : sigmaScore}
-                </span>
-              </div>
-            </div>
+            )}
 
-            {/* SIGMA reclassifications vs keyword */}
+            {/* AI reclassifications vs keyword */}
             {changed.length > 0 && (
               <div className="space-y-1.5">
                 <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
@@ -350,11 +464,12 @@ export function AnalysisSummaryCard({
                     neutral: kwNeutral,
                     score: `${kwScore > 0 ? '+' : ''}${kwScore}`,
                     total: kwTotal,
-                    overall: kwOverall === 'BULLISH'
-                      ? t('news.bullish')
-                      : kwOverall === 'BEARISH'
-                        ? t('news.bearish')
-                        : t('news.neutral'),
+                    overall:
+                      kwOverall === 'BULLISH'
+                        ? t('news.bullish')
+                        : kwOverall === 'BEARISH'
+                          ? t('news.bearish')
+                          : t('news.neutral'),
                   })}
                 </p>
               )}

--- a/apps/web/src/components/onboarding/types.ts
+++ b/apps/web/src/components/onboarding/types.ts
@@ -37,14 +37,7 @@ export const LLM_PROVIDERS: {
   {
     value: 'OPENROUTER',
     label: 'OpenRouter',
-    models: [
-      'anthropic/claude-sonnet-4.6',
-      'google/gemini-3-flash-preview',
-      'deepseek/deepseek-v3.2',
-      'google/gemini-2.5-flash-lite',
-      'openrouter/elephant-alpha',
-      'nvidia/nemotron-3-super-120b-a12b:free',
-    ],
+    models: [], // Resolved dynamically via useOpenRouterModels hook
     helpLink: 'https://openrouter.ai/keys',
     helpLinkText: 'openrouter.ai',
   },

--- a/apps/web/src/containers/admin/admin-agent-config-cards.tsx
+++ b/apps/web/src/containers/admin/admin-agent-config-cards.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   Save,
   Loader2,
@@ -7,6 +7,9 @@ import {
   Scale,
   DollarSign,
   RotateCcw,
+  ShieldAlert,
+  Sparkles,
+  ChevronRight,
 } from 'lucide-react';
 import { Button, Select, type SelectOption } from '@crypto-trader/ui';
 import { useTranslation } from 'react-i18next';
@@ -14,9 +17,12 @@ import {
   useAdminAgentConfigs,
   useUpdateAdminAgentConfig,
   useApplyAdminPreset,
+  useAutoResolveFallback,
   type AgentPresetName,
 } from '../../hooks/use-agent-config';
+import { useLLMKeys, useUpdateLLMModel } from '../../hooks/use-user';
 import { DynamicModelSelect } from '../settings/dynamic-model-select';
+import { OpenRouterModelSelect } from '../settings/openrouter-model-select';
 import { cn } from '../../lib/utils';
 import { Dialog } from '@crypto-trader/ui';
 
@@ -78,19 +84,26 @@ function AdminAgentConfigCard({
   const canSave = isDirty && model.trim() !== '';
 
   return (
-    <div className="rounded-xl border border-border bg-card p-4 space-y-3">
-      <div className="flex items-center gap-2">
-        {meta.locked && <Lock className="h-4 w-4 text-red-500" />}
-        <span className={cn('font-bold text-sm', meta.color)}>
-          {meta.codename}
-        </span>
-        <span className="text-xs text-muted-foreground">
-          ({config.agentId})
-        </span>
+    <div className="rounded-xl border border-border bg-card p-4 space-y-3 h-full">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          {meta.locked && <Lock className="h-4 w-4 text-red-500" />}
+          <span className={cn('font-bold text-sm', meta.color)}>
+            {meta.codename}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            ({config.agentId})
+          </span>
+        </div>
+        {isDirty && (
+          <span className="text-[10px] px-2 py-0.5 rounded-full bg-amber-500/10 text-amber-400 border border-amber-500/20">
+            {t('settings.agents.unsaved', { defaultValue: 'Unsaved' })}
+          </span>
+        )}
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <div>
+      <div className="space-y-3">
+        <div className="w-full">
           <Select
             label={t('settings.agents.provider')}
             value={provider}
@@ -98,15 +111,13 @@ function AdminAgentConfigCard({
             options={PROVIDERS}
           />
         </div>
-        <div>
-          <DynamicModelSelect
-            provider={provider}
-            value={model}
-            onChange={setModel}
-            fallbackModels={[]}
-            label={t('settings.agents.model')}
-          />
-        </div>
+        <DynamicModelSelect
+          provider={provider}
+          value={model}
+          onChange={setModel}
+          fallbackModels={[]}
+          label={t('settings.agents.model')}
+        />
       </div>
 
       <div className="flex items-center gap-2 pt-1">
@@ -123,6 +134,21 @@ function AdminAgentConfigCard({
           )}
           <span className="ml-1">{t('common.save')}</span>
         </Button>
+        {isDirty && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setProvider(config.provider || 'OPENROUTER');
+              setModel(config.model || '');
+            }}
+          >
+            <RotateCcw className="h-3 w-3" />
+            <span className="ml-1">
+              {t('settings.agents.reset', { defaultValue: 'Reset' })}
+            </span>
+          </Button>
+        )}
       </div>
     </div>
   );
@@ -133,10 +159,29 @@ export function AdminAgentConfigCards() {
   const { data: configs, isLoading } = useAdminAgentConfigs();
   const updateMutation = useUpdateAdminAgentConfig();
   const applyPreset = useApplyAdminPreset();
+  const autoResolve = useAutoResolveFallback();
+  const { data: llmKeys } = useLLMKeys();
+  const updateLLMModel = useUpdateLLMModel();
   const [pendingPreset, setPendingPreset] = useState<{
     id: AgentPresetName;
     name: string;
   } | null>(null);
+
+  // Fallback model state
+  const openRouterCred = (llmKeys ?? []).find(
+    (k) => k.provider === 'OPENROUTER' && k.isActive,
+  );
+  const [fallbackModel, setFallbackModel] = useState(
+    openRouterCred?.selectedModel ?? '',
+  );
+  const [fallbackDirty, setFallbackDirty] = useState(false);
+
+  useEffect(() => {
+    if (openRouterCred?.selectedModel) {
+      setFallbackModel(openRouterCred.selectedModel);
+      setFallbackDirty(false);
+    }
+  }, [openRouterCred?.selectedModel]);
 
   const PRESET_OPTIONS: Array<{
     id: AgentPresetName;
@@ -194,6 +239,17 @@ export function AdminAgentConfigCards() {
       </div>
     );
   }
+
+  const allConfigs = useMemo(() => configs ?? [], [configs]);
+  const [selectedAgentId, setSelectedAgentId] = useState<string>('');
+
+  useEffect(() => {
+    if (allConfigs.length > 0 && !selectedAgentId) {
+      setSelectedAgentId(allConfigs[0].agentId);
+    }
+  }, [allConfigs, selectedAgentId]);
+
+  const selectedConfig = allConfigs.find((c) => c.agentId === selectedAgentId);
 
   return (
     <div className="space-y-6">
@@ -276,6 +332,84 @@ export function AdminAgentConfigCards() {
         </div>
       </div>
 
+      {/* ── Fallback Model ──────────────────────────────────────────── */}
+      {openRouterCred && (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <ShieldAlert className="h-4 w-4 text-amber-500" />
+              <h2 className="text-sm font-semibold">
+                {t('settings.agents.fallback.title', {
+                  defaultValue: 'Fallback Model',
+                })}
+              </h2>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={autoResolve.isPending}
+              onClick={() => autoResolve.mutate()}
+            >
+              {autoResolve.isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin mr-1" />
+              ) : (
+                <Sparkles className="h-3 w-3 mr-1" />
+              )}
+              {t('settings.agents.fallback.autoResolve', {
+                defaultValue: 'Auto-resolve',
+              })}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {t('admin.fallbackDescription', {
+              defaultValue:
+                'Default fallback model used platform-wide when a user has no custom configuration. Applied automatically by presets.',
+            })}
+          </p>
+          <OpenRouterModelSelect
+            value={fallbackModel}
+            onChange={(m) => {
+              setFallbackModel(m);
+              setFallbackDirty(true);
+            }}
+            compact
+          />
+          {fallbackDirty && (
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                disabled={updateLLMModel.isPending || !fallbackModel}
+                onClick={() =>
+                  updateLLMModel.mutate(
+                    {
+                      provider: 'OPENROUTER',
+                      selectedModel: fallbackModel,
+                    },
+                    { onSuccess: () => setFallbackDirty(false) },
+                  )
+                }
+              >
+                {updateLLMModel.isPending && (
+                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                )}
+                <Save className="h-3 w-3 mr-1" />
+                {t('common.save')}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setFallbackModel(openRouterCred?.selectedModel ?? '');
+                  setFallbackDirty(false);
+                }}
+              >
+                {t('common.cancel', { defaultValue: 'Cancel' })}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Description */}
       <div className="rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
         {t('agents.modelsTabDesc', {
@@ -284,18 +418,76 @@ export function AdminAgentConfigCards() {
         })}
       </div>
 
-      {/* Agent cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {(configs ?? []).map((cfg) => (
-          <AdminAgentConfigCard
-            key={cfg.agentId}
-            config={cfg}
-            onSave={(agentId, provider, model) =>
-              updateMutation.mutate({ agentId, provider, model })
-            }
-            isSaving={updateMutation.isPending}
+      {/* ── Agent Configuration — Vertical Tabs ─────────────────── */}
+      <div className="space-y-3">
+        {/* Mobile: dropdown selector */}
+        <div className="block md:hidden">
+          <Select
+            value={selectedAgentId}
+            onChange={setSelectedAgentId}
+            options={allConfigs.map((cfg) => {
+              const m = AGENT_META[cfg.agentId] ?? {
+                codename: cfg.agentId,
+                color: '',
+              };
+              return {
+                value: cfg.agentId,
+                label: `${m.codename} (${cfg.agentId})`,
+              };
+            })}
           />
-        ))}
+        </div>
+
+        <div className="flex gap-4 items-stretch">
+          {/* Desktop: vertical nav */}
+          <div className="hidden md:flex flex-col gap-1 w-48 shrink-0 rounded-xl border border-border bg-card p-2">
+            {allConfigs.map((cfg) => {
+              const m = AGENT_META[cfg.agentId] ?? {
+                codename: cfg.agentId,
+                color: 'text-muted-foreground',
+              };
+              const isActive = cfg.agentId === selectedAgentId;
+              return (
+                <button
+                  key={cfg.agentId}
+                  type="button"
+                  onClick={() => setSelectedAgentId(cfg.agentId)}
+                  className={cn(
+                    'flex items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-all duration-150',
+                    isActive
+                      ? 'bg-primary/10 text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                  )}
+                >
+                  {m.locked && (
+                    <Lock className="h-3.5 w-3.5 text-red-500 shrink-0" />
+                  )}
+                  <span className={cn('font-bold', m.color)}>{m.codename}</span>
+                  <span className="text-[10px] text-muted-foreground truncate">
+                    {cfg.agentId}
+                  </span>
+                  {isActive && (
+                    <ChevronRight className="ml-auto h-3.5 w-3.5 text-primary shrink-0" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Card content */}
+          <div className="flex-1 min-w-0">
+            {selectedConfig && (
+              <AdminAgentConfigCard
+                key={selectedConfig.agentId}
+                config={selectedConfig}
+                onSave={(agentId, provider, model) =>
+                  updateMutation.mutate({ agentId, provider, model })
+                }
+                isSaving={updateMutation.isPending}
+              />
+            )}
+          </div>
+        </div>
       </div>
 
       {/* Confirmation dialog */}

--- a/apps/web/src/containers/admin/admin-provider-status-panel.tsx
+++ b/apps/web/src/containers/admin/admin-provider-status-panel.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Shield, Power } from 'lucide-react';
+import { Badge, Dialog, ToggleSwitch } from '@crypto-trader/ui';
+import { useTranslation } from 'react-i18next';
+import {
+  useAdminLLMProviderStatus,
+  useToggleLLMProvider,
+  type PlatformLLMProviderStatus,
+} from '../../hooks/use-admin';
+
+export function AdminProviderStatusPanel() {
+  const { t } = useTranslation();
+  const { data: providers = [], isLoading } = useAdminLLMProviderStatus();
+  const { mutate: toggleProvider, isPending } = useToggleLLMProvider();
+  const [confirmTarget, setConfirmTarget] =
+    useState<PlatformLLMProviderStatus | null>(null);
+
+  function handleToggle(provider: PlatformLLMProviderStatus) {
+    if (provider.isActive) {
+      setConfirmTarget(provider);
+    } else {
+      toggleProvider(provider.provider);
+    }
+  }
+
+  function confirmDisable() {
+    if (confirmTarget) {
+      toggleProvider(confirmTarget.provider);
+      setConfirmTarget(null);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="rounded-xl border border-border bg-card p-5 animate-pulse">
+        <div className="h-6 w-48 bg-muted rounded" />
+        <div className="mt-4 space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-10 bg-muted rounded" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="rounded-xl border border-border bg-card p-5">
+        <h2 className="mb-4 font-semibold flex items-center gap-2">
+          <Shield className="h-4 w-4 text-primary" />
+          {t('admin.providerStatusTitle')}
+        </h2>
+        <p className="mb-4 text-sm text-muted-foreground">
+          {t('admin.providerStatusSubtitle')}
+        </p>
+
+        <div className="divide-y divide-border">
+          {providers.map((p) => (
+            <div
+              key={p.provider}
+              className="flex items-center justify-between py-3"
+            >
+              <div className="flex items-center gap-3">
+                <Power
+                  className={`h-4 w-4 ${p.isActive ? 'text-green-400' : 'text-red-400'}`}
+                />
+                <span className="font-medium">{p.provider}</span>
+                <Badge
+                  variant={p.isActive ? 'success' : 'error'}
+                  label={
+                    p.isActive
+                      ? t('admin.providerActive')
+                      : t('admin.providerInactive')
+                  }
+                />
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-muted-foreground">
+                  {new Date(p.updatedAt).toLocaleDateString()}
+                </span>
+                <ToggleSwitch
+                  checked={p.isActive}
+                  onChange={() => handleToggle(p)}
+                  disabled={isPending}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <Dialog
+        open={!!confirmTarget}
+        onClose={() => setConfirmTarget(null)}
+        title={t('admin.providerToggleConfirmTitle')}
+        variant="danger"
+        onConfirm={confirmDisable}
+        confirmLabel={t('admin.providerToggleConfirmAction')}
+        cancelLabel={t('common.cancel')}
+      >
+        <p className="text-sm text-muted-foreground">
+          {t('admin.providerToggleConfirmDesc', {
+            provider: confirmTarget?.provider,
+          })}
+        </p>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/containers/chat/chat-llm-override.tsx
+++ b/apps/web/src/containers/chat/chat-llm-override.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
-import { ChevronDown, Search } from 'lucide-react';
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { ChevronDown, Search, Coins, Zap } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import {
   useChatLLMOptions,
@@ -7,6 +7,10 @@ import {
   LLMOption,
 } from '../../hooks/use-chat';
 import { useLLMProviderModels, type LLMModel } from '../../hooks/use-llm';
+import {
+  useOpenRouterModels,
+  type OpenRouterModelInfo,
+} from '../../hooks/use-openrouter-models';
 import { useChatStore } from '../../store/chat.store';
 import { useTranslation } from 'react-i18next';
 
@@ -20,24 +24,17 @@ const PROVIDER_COLORS: Record<string, string> = {
   OPENROUTER: 'text-purple-400',
 };
 
-// ── OpenRouter category filters ─────────────────────────────────────────────
+// ── OpenRouter category labels (mapped from API-derived categories) ──────────
 
-type ORCategory =
-  | 'top-paid'
-  | 'free'
-  | 'all'
-  | 'reasoning'
-  | 'fast'
-  | 'analytics';
-
-const OR_CATEGORIES: { value: ORCategory; labelKey: string }[] = [
-  { value: 'top-paid', labelKey: 'settings.orCategory.topPaid' },
-  { value: 'free', labelKey: 'settings.orCategory.free' },
-  { value: 'all', labelKey: 'settings.orCategory.all' },
-  { value: 'reasoning', labelKey: 'settings.orCategory.reasoning' },
-  { value: 'fast', labelKey: 'settings.orCategory.fast' },
-  { value: 'analytics', labelKey: 'settings.orCategory.analytics' },
-];
+// i18n label map — categories come from model data, not hardcoded
+const CATEGORY_LABEL_MAP: Record<string, string> = {
+  free: 'settings.orPrice.free',
+  reasoning: 'settings.orCategory.reasoning',
+  'tool-use': 'settings.orCategory.toolUse',
+  fast: 'settings.orCategory.fast',
+  'long-context': 'settings.orCategory.longContext',
+  premium: 'settings.orCategory.premium',
+};
 
 // ── Component ───────────────────────────────────────────────────────────────
 
@@ -59,17 +56,33 @@ export function ChatLLMOverride({
 
   const [providerOpen, setProviderOpen] = useState(false);
   const [modelOpen, setModelOpen] = useState(false);
-  const [category, setCategory] = useState<ORCategory>('top-paid');
+  const [category, setCategory] = useState<string>('');
   const [search, setSearch] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const isOpenRouter = sessionProvider === 'OPENROUTER';
 
-  // Fetch dynamic models for OpenRouter
-  const { data: orModels } = useLLMProviderModels(
-    isOpenRouter ? 'OPENROUTER' : '',
-  );
+  // Fetch dynamic models from new OpenRouter endpoint
+  const { data: orModelsRaw } = useOpenRouterModels();
+
+  // Derive available categories dynamically from model data
+  const orCategories = useMemo(() => {
+    if (!orModelsRaw) return [];
+    const catSet = new Set<string>();
+    for (const m of orModelsRaw) {
+      for (const c of m.categories) catSet.add(c);
+    }
+    return [
+      { value: '', labelKey: 'settings.orCategory.allCategories' },
+      ...Array.from(catSet)
+        .sort()
+        .map((c) => ({
+          value: c,
+          labelKey: CATEGORY_LABEL_MAP[c] || c,
+        })),
+    ];
+  }, [orModelsRaw]);
 
   useEffect(() => {
     function handleOutsideClick(e: MouseEvent) {
@@ -90,12 +103,22 @@ export function ChatLLMOverride({
 
   // For OpenRouter: filter models by selected category
   const orFiltered =
-    isOpenRouter && orModels
-      ? category === 'all'
-        ? orModels.filter((m) => !m.deprecated)
-        : orModels.filter(
-            (m) => !m.deprecated && m.categories?.includes(category),
-          )
+    isOpenRouter && orModelsRaw
+      ? (() => {
+          let models = [...orModelsRaw];
+          if (category === 'free') {
+            models = models.filter((m) => m.isFree);
+          } else if (category) {
+            models = models.filter((m) => m.categories.includes(category));
+          }
+          // Sort: paid by price desc, free by context desc
+          models.sort((a, b) => {
+            if (a.isFree !== b.isFree) return a.isFree ? 1 : -1;
+            if (!a.isFree) return b.pricing.completion - a.pricing.completion;
+            return b.contextLength - a.contextLength;
+          });
+          return models;
+        })()
       : [];
 
   // For non-OpenRouter providers
@@ -103,25 +126,28 @@ export function ChatLLMOverride({
 
   // Auto-switch category if current model is not visible
   useEffect(() => {
-    if (!isOpenRouter || !orModels?.length || !sessionModel) return;
+    if (!isOpenRouter || !orModelsRaw?.length || !sessionModel) return;
     const visible = orFiltered.some((m) => m.id === sessionModel);
     if (!visible) {
-      for (const cat of OR_CATEGORIES) {
-        if (cat.value === 'all') {
-          setCategory('all');
-          break;
-        }
-        if (
-          orModels.some(
-            (m) => m.id === sessionModel && m.categories?.includes(cat.value),
-          )
-        ) {
-          setCategory(cat.value);
-          break;
+      // Try to find a specific category that contains this model
+      const model = orModelsRaw.find((m) => m.id === sessionModel);
+      if (model) {
+        if (model.isFree) {
+          setCategory('free');
+        } else if (model.categories.length > 0) {
+          const matchedCat = orCategories.find(
+            (c) =>
+              c.value &&
+              c.value !== 'free' &&
+              model.categories.includes(c.value),
+          );
+          setCategory(matchedCat?.value ?? '');
+        } else {
+          setCategory('');
         }
       }
     }
-  }, [sessionModel, orModels]);
+  }, [sessionModel, orModelsRaw]);
 
   const handleProviderSelect = (opt: LLMOption) => {
     const newModel = opt.models[0] ?? sessionModel;
@@ -135,7 +161,7 @@ export function ChatLLMOverride({
     setSearch('');
   };
 
-  const handleCategorySelect = (cat: ORCategory) => {
+  const handleCategorySelect = (cat: string) => {
     setCategory(cat);
     setProviderOpen(false);
   };
@@ -147,8 +173,8 @@ export function ChatLLMOverride({
   // Active category label for display
   const activeCategoryLabel = isOpenRouter
     ? t(
-        OR_CATEGORIES.find((c) => c.value === category)?.labelKey ??
-          'settings.orCategory.topPaid',
+        orCategories.find((c) => c.value === category)?.labelKey ??
+          'settings.orCategory.allCategories',
       )
     : null;
 
@@ -190,7 +216,7 @@ export function ChatLLMOverride({
           <div className="absolute bg-background bottom-full left-0 z-50 mb-1 min-w-[140px] rounded-lg border border-border bg-popover p-1 shadow-lg">
             {isOpenRouter && options.length <= 1
               ? /* Category list for OpenRouter-only */
-                OR_CATEGORIES.map((cat) => (
+                orCategories.map((cat) => (
                   <button
                     key={cat.value}
                     type="button"
@@ -238,7 +264,7 @@ export function ChatLLMOverride({
       {isOpenRouter && options.length > 1 && (
         <div className="flex items-center gap-0.5">
           <span className="text-muted-foreground/40 mx-0.5">·</span>
-          {OR_CATEGORIES.map((cat) => (
+          {orCategories.map((cat) => (
             <button
               key={cat.value}
               type="button"
@@ -302,7 +328,7 @@ export function ChatLLMOverride({
                       (m) =>
                         !q ||
                         m.id.toLowerCase().includes(q) ||
-                        (m.label ?? '').toLowerCase().includes(q),
+                        m.name.toLowerCase().includes(q),
                     );
                     return visible.length > 0 ? (
                       visible.map((m) => (
@@ -316,12 +342,23 @@ export function ChatLLMOverride({
                             m.id === sessionModel && 'bg-muted/40 font-medium',
                           )}
                         >
-                          <span className="truncate">{m.label ?? m.id}</span>
-                          {m.contextWindow && (
-                            <span className="ml-2 shrink-0 text-[10px] text-muted-foreground/50">
-                              {(m.contextWindow / 1000).toFixed(0)}K
-                            </span>
-                          )}
+                          <span className="flex items-center gap-1.5 truncate">
+                            {m.isFree ? (
+                              <Zap className="h-3 w-3 shrink-0 text-emerald-400" />
+                            ) : (
+                              <Coins className="h-3 w-3 shrink-0 text-amber-400" />
+                            )}
+                            <span className="truncate">{m.name}</span>
+                          </span>
+                          <span className="ml-2 shrink-0 text-[10px] text-muted-foreground/50">
+                            {m.isFree
+                              ? 'Free'
+                              : `$${m.pricing.completion < 1 ? m.pricing.completion.toFixed(2) : m.pricing.completion.toFixed(1)}/M`}
+                            {' · '}
+                            {m.contextLength >= 1_000_000
+                              ? `${(m.contextLength / 1_000_000).toFixed(1)}M`
+                              : `${(m.contextLength / 1000).toFixed(0)}K`}
+                          </span>
                         </button>
                       ))
                     ) : (

--- a/apps/web/src/containers/dashboard-header-container.tsx
+++ b/apps/web/src/containers/dashboard-header-container.tsx
@@ -7,11 +7,13 @@ import { AvatarDropdown } from './avatar-dropdown';
 import { Link } from 'react-router-dom';
 import { ConnectionStatusDropdown } from './connection-status-dropdown';
 import { ModeSelector } from './mode-selector';
+import { useAuthStore } from '../store/auth.store';
 
 export function DashboardHeader() {
   const unreadCount = useUnreadCount();
   const [notifOpen, setNotifOpen] = useState(false);
   const { openMobile } = useSidebarStore();
+  const user = useAuthStore((s) => s.user);
 
   return (
     <header className="flex h-14 shrink-0 items-center justify-between gap-1 border-b border-border/60 bg-card/50 px-4 backdrop-blur-sm">
@@ -33,8 +35,8 @@ export function DashboardHeader() {
 
       {/* Right actions */}
       <div className="flex items-center gap-1.5">
-        {/* Operation mode selector */}
-        <ModeSelector />
+        {/* Operation mode selector — only for traders */}
+        {user?.role !== 'ADMIN' && <ModeSelector />}
 
         {/* Connection status */}
         <ConnectionStatusDropdown />

--- a/apps/web/src/containers/settings/dynamic-model-select.tsx
+++ b/apps/web/src/containers/settings/dynamic-model-select.tsx
@@ -4,25 +4,7 @@ import { useLLMProviderModels, type LLMModel } from '../../hooks/use-llm';
 import { Select, type SelectOption } from '@crypto-trader/ui';
 import { Cpu, Loader2, Sparkles } from 'lucide-react';
 import { cn } from '../../lib/utils';
-
-// ── OpenRouter category filters (driven by backend `categories` field) ──────
-
-type ORCategory =
-  | 'top-paid'
-  | 'free'
-  | 'all'
-  | 'reasoning'
-  | 'fast'
-  | 'analytics';
-
-const OR_CATEGORIES: { value: ORCategory; labelKey: string }[] = [
-  { value: 'top-paid', labelKey: 'settings.orCategory.topPaid' },
-  { value: 'free', labelKey: 'settings.orCategory.free' },
-  { value: 'all', labelKey: 'settings.orCategory.all' },
-  { value: 'reasoning', labelKey: 'settings.orCategory.reasoning' },
-  { value: 'fast', labelKey: 'settings.orCategory.fast' },
-  { value: 'analytics', labelKey: 'settings.orCategory.analytics' },
-];
+import { OpenRouterModelSelect } from './openrouter-model-select';
 
 // ── Component ───────────────────────────────────────────────────────────────
 
@@ -44,10 +26,28 @@ export function DynamicModelSelect({
   className = '',
 }: DynamicModelSelectProps) {
   const { t } = useTranslation();
-  const { data: models, isLoading, isError } = useLLMProviderModels(provider);
   const isOpenRouter = provider === 'OPENROUTER';
-  const [category, setCategory] = useState<ORCategory>('top-paid');
+
+  // For non-OpenRouter providers, fetch models from the provider-specific endpoint
+  const {
+    data: models,
+    isLoading,
+    isError,
+  } = useLLMProviderModels(provider, !isOpenRouter);
   const [showAll, setShowAll] = useState(false);
+
+  // Delegate to dedicated OpenRouter component for rich filtering
+  if (isOpenRouter) {
+    return (
+      <OpenRouterModelSelect
+        value={value}
+        onChange={onChange}
+        label={label}
+        className={className}
+        compact
+      />
+    );
+  }
 
   const autoOption: SelectOption = {
     value: '',
@@ -60,7 +60,6 @@ export function DynamicModelSelect({
   // Build all options, excluding deprecated
   const allOptions: (SelectOption & {
     _recommended?: boolean;
-    _categories?: string[];
   })[] = allModels
     ? allModels
         .filter((m) => !m.deprecated)
@@ -73,7 +72,6 @@ export function DynamicModelSelect({
           icon: <Cpu className="h-3.5 w-3.5 text-muted-foreground" />,
           disabled: false,
           _recommended: m.recommended,
-          _categories: m.categories,
         }))
     : fallbackModels.map((m) => ({
         value: m,
@@ -83,10 +81,9 @@ export function DynamicModelSelect({
 
   const hasRecommended = allOptions.some((o) => o._recommended);
 
-  // For non-OpenRouter: auto-expand if saved model isn't in recommended
+  // Auto-expand if saved model isn't in recommended
   useEffect(() => {
     if (
-      !isOpenRouter &&
       value &&
       allOptions.some((o) => o.value === value) &&
       hasRecommended &&
@@ -98,44 +95,12 @@ export function DynamicModelSelect({
     }
   }, [value, allModels]);
 
-  // For OpenRouter: sync category to the model's natural category whenever value changes
-  useEffect(() => {
-    if (!isOpenRouter || !value || !allModels) return;
-    // Find the most specific category that contains this model
-    for (const cat of OR_CATEGORIES) {
-      if (cat.value === 'all') continue;
-      if (
-        allOptions.some(
-          (o) => o.value === value && o._categories?.includes(cat.value),
-        )
-      ) {
-        setCategory(cat.value);
-        return;
-      }
-    }
-    // Model exists but has no specific category → show all
-    if (allOptions.some((o) => o.value === value)) {
-      setCategory('all');
-    }
-  }, [value, allModels]);
-
   // Apply filtering
-  let filteredModels: SelectOption[];
-  if (isOpenRouter) {
-    if (category === 'all') {
-      filteredModels = allOptions;
-    } else {
-      filteredModels = allOptions.filter((o) =>
-        o._categories?.includes(category),
+  const filteredModels = showAll
+    ? allOptions
+    : allOptions.filter(
+        (o) => !o.disabled && (!hasRecommended || o._recommended),
       );
-    }
-  } else {
-    filteredModels = showAll
-      ? allOptions
-      : allOptions.filter(
-          (o) => !o.disabled && (!hasRecommended || o._recommended),
-        );
-  }
 
   const options: SelectOption[] = [autoOption, ...filteredModels];
 
@@ -154,53 +119,31 @@ export function DynamicModelSelect({
     );
   }
 
-  // OpenRouter: category pills
-  const orCategorySelector = isOpenRouter ? (
-    <div className="flex flex-wrap gap-1">
-      {OR_CATEGORIES.map((cat) => (
-        <button
-          key={cat.value}
-          type="button"
-          onClick={() => setCategory(cat.value)}
-          className={cn(
-            'text-[10px] px-2 py-0.5 rounded-full border transition-colors',
-            category === cat.value
-              ? 'bg-primary/10 border-primary/30 text-primary'
-              : 'bg-muted/50 border-border text-muted-foreground hover:text-foreground',
-          )}
-        >
-          {t(cat.labelKey, { defaultValue: cat.value })}
-        </button>
-      ))}
-    </div>
+  // Recommended/all toggle
+  const badgeButton = hasRecommended ? (
+    <button
+      type="button"
+      onClick={() => setShowAll(!showAll)}
+      className={cn(
+        'text-[10px] px-2 py-0.5 rounded-full border transition-colors',
+        showAll
+          ? 'bg-amber-500/10 border-amber-500/30 text-amber-400'
+          : 'bg-primary/10 border-primary/30 text-primary',
+      )}
+    >
+      {showAll
+        ? t('settings.modelFilter.all', { defaultValue: 'Todos' })
+        : t('settings.modelFilter.recommended', {
+            defaultValue: 'Recomendados',
+          })}
+    </button>
   ) : null;
 
-  // Other providers: recommended/all toggle
-  const badgeButton =
-    !isOpenRouter && hasRecommended ? (
-      <button
-        type="button"
-        onClick={() => setShowAll(!showAll)}
-        className={cn(
-          'text-[10px] px-2 py-0.5 rounded-full border transition-colors',
-          showAll
-            ? 'bg-amber-500/10 border-amber-500/30 text-amber-400'
-            : 'bg-primary/10 border-primary/30 text-primary',
-        )}
-      >
-        {showAll
-          ? t('settings.modelFilter.all', { defaultValue: 'Todos' })
-          : t('settings.modelFilter.recommended', {
-              defaultValue: 'Recomendados',
-            })}
-      </button>
-    ) : null;
-
-  const valueInFilteredOptions = options.some((o) => o.value === value);
-  const valueExistsInAnyCategory = allOptions.some((o) => o.value === value);
+  const valueInOptions = options.some((o) => o.value === value);
+  const valueExistsInAll = allOptions.some((o) => o.value === value);
   // Only add as custom option if the model doesn't exist in the provider's model list at all
   const effectiveOptions: SelectOption[] =
-    value && !valueInFilteredOptions && !valueExistsInAnyCategory
+    value && !valueInOptions && !valueExistsInAll
       ? [
           ...options,
           {
@@ -226,8 +169,7 @@ export function DynamicModelSelect({
           defaultValue: 'Search model...',
         })}
       />
-      {orCategorySelector && <div className="mt-2">{orCategorySelector}</div>}
-      {!isOpenRouter && showAll && (
+      {showAll && (
         <p className="mt-1 text-[10px] text-amber-400">
           ⚠️{' '}
           {t('settings.modelFilter.warning', {

--- a/apps/web/src/containers/settings/openrouter-model-select.tsx
+++ b/apps/web/src/containers/settings/openrouter-model-select.tsx
@@ -1,0 +1,370 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Select, type SelectOption, ModelInfoModal } from '@crypto-trader/ui';
+import {
+  useOpenRouterModels,
+  type OpenRouterModelInfo,
+} from '../../hooks/use-openrouter-models';
+import { Cpu, Info, Loader2, Sparkles, Coins, Zap } from 'lucide-react';
+
+// ── Filters ─────────────────────────────────────────────────────────────────
+
+type SortMode = 'smart' | 'price-asc' | 'price-desc' | 'context';
+
+const SORT_OPTIONS: { value: SortMode; labelKey: string }[] = [
+  { value: 'smart', labelKey: 'settings.orSort.smart' },
+  { value: 'price-asc', labelKey: 'settings.orSort.cheapest' },
+  { value: 'price-desc', labelKey: 'settings.orSort.mostCapable' },
+  { value: 'context', labelKey: 'settings.orSort.longestContext' },
+];
+
+type PriceFilter = 'all' | 'free' | 'paid';
+
+const PRICE_OPTIONS: { value: PriceFilter; labelKey: string }[] = [
+  { value: 'all', labelKey: 'settings.orPrice.all' },
+  { value: 'free', labelKey: 'settings.orPrice.free' },
+  { value: 'paid', labelKey: 'settings.orPrice.paid' },
+];
+
+// i18n label map for known categories — keys come from API model data
+const CATEGORY_LABEL_MAP: Record<string, string> = {
+  reasoning: 'settings.orCategory.reasoning',
+  'tool-use': 'settings.orCategory.toolUse',
+  fast: 'settings.orCategory.fast',
+  'long-context': 'settings.orCategory.longContext',
+  premium: 'settings.orCategory.premium',
+};
+
+// Categories already covered by the Price filter
+const HIDDEN_CATEGORIES = new Set(['free', 'paid']);
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatPrice(pricePerMillion: number): string {
+  if (pricePerMillion === 0) return 'Free';
+  if (pricePerMillion < 0.1) return `$${pricePerMillion.toFixed(3)}/M`;
+  if (pricePerMillion < 1) return `$${pricePerMillion.toFixed(2)}/M`;
+  return `$${pricePerMillion.toFixed(1)}/M`;
+}
+
+function formatContext(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M ctx`;
+  return `${(tokens / 1_000).toFixed(0)}K ctx`;
+}
+
+function smartScore(m: OpenRouterModelInfo): number {
+  // Higher = better. Weighs pricing (proxy for quality) + context length
+  let score = 0;
+  if (m.isFree) {
+    score = m.contextLength >= 200_000 ? 25 : 15;
+  } else if (m.pricing.completion >= 10) {
+    score = 90;
+  } else if (m.pricing.completion >= 3) {
+    score = 70;
+  } else if (m.pricing.completion >= 1) {
+    score = 50;
+  } else {
+    score = 35;
+  }
+  // Bonus for large context
+  score += Math.min(m.contextLength / 100_000, 10);
+  return score;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+interface OpenRouterModelSelectProps {
+  value: string;
+  onChange: (model: string) => void;
+  label?: string;
+  className?: string;
+  /** Compact mode: filters in a single row with smaller labels */
+  compact?: boolean;
+}
+
+export function OpenRouterModelSelect({
+  value,
+  onChange,
+  label,
+  className = '',
+  compact = false,
+}: OpenRouterModelSelectProps) {
+  const { t } = useTranslation();
+  const { data: allModels, isLoading } = useOpenRouterModels();
+
+  const [category, setCategory] = useState<string>('');
+  const [priceFilter, setPriceFilter] = useState<PriceFilter>('all');
+  const [sortMode, setSortMode] = useState<SortMode>('smart');
+  const [infoOpen, setInfoOpen] = useState(false);
+
+  // Derive available categories dynamically from model data
+  const availableCategories = useMemo(() => {
+    if (!allModels) return [];
+    const catSet = new Set<string>();
+    for (const m of allModels) {
+      for (const c of m.categories) {
+        if (!HIDDEN_CATEGORIES.has(c)) catSet.add(c);
+      }
+    }
+    return Array.from(catSet).sort();
+  }, [allModels]);
+
+  // Auto-detect category of currently selected model
+  useEffect(() => {
+    if (!value || !allModels) return;
+    const selected = allModels.find((m) => m.id === value);
+    if (!selected) return;
+
+    // Auto-set price filter based on model
+    if (selected.isFree && priceFilter === 'paid') {
+      setPriceFilter('all');
+    } else if (!selected.isFree && priceFilter === 'free') {
+      setPriceFilter('all');
+    }
+  }, [value, allModels]);
+
+  // Build filtered + sorted model options
+  const modelOptions = useMemo(() => {
+    if (!allModels) return [];
+
+    let filtered = [...allModels];
+
+    // Price filter
+    if (priceFilter === 'free') {
+      filtered = filtered.filter((m) => m.isFree);
+    } else if (priceFilter === 'paid') {
+      filtered = filtered.filter((m) => !m.isFree);
+    }
+
+    // Category filter
+    if (category) {
+      filtered = filtered.filter((m) => m.categories.includes(category));
+    }
+
+    // Sort
+    switch (sortMode) {
+      case 'smart':
+        filtered.sort((a, b) => smartScore(b) - smartScore(a));
+        break;
+      case 'price-asc':
+        filtered.sort((a, b) => a.pricing.completion - b.pricing.completion);
+        break;
+      case 'price-desc':
+        filtered.sort((a, b) => b.pricing.completion - a.pricing.completion);
+        break;
+      case 'context':
+        filtered.sort((a, b) => b.contextLength - a.contextLength);
+        break;
+    }
+
+    return filtered;
+  }, [allModels, category, priceFilter, sortMode]);
+
+  // Build SelectOption array
+  const autoOption: SelectOption = {
+    value: '',
+    label: t('config.stepper.autoSelect', {
+      defaultValue: 'Auto (recommended)',
+    }),
+    icon: <Sparkles className="h-3.5 w-3.5 text-primary" />,
+  };
+
+  const options: SelectOption[] = [
+    autoOption,
+    ...modelOptions.map(
+      (m): SelectOption => ({
+        value: m.id,
+        label: m.name,
+        description: [
+          m.isFree ? '🆓 Free' : `${formatPrice(m.pricing.completion)} out`,
+          formatContext(m.contextLength),
+        ].join(' · '),
+        icon: m.isFree ? (
+          <Zap className="h-3.5 w-3.5 text-emerald-400" />
+        ) : (
+          <Coins className="h-3.5 w-3.5 text-amber-400" />
+        ),
+      }),
+    ),
+  ];
+
+  // Ensure currently selected model appears even if filtered out
+  const valueInOptions = options.some((o) => o.value === value);
+  if (value && !valueInOptions) {
+    const selectedModel = allModels?.find((m) => m.id === value);
+    if (selectedModel) {
+      options.push({
+        value: selectedModel.id,
+        label: selectedModel.name,
+        description: [
+          selectedModel.isFree
+            ? '🆓 Free'
+            : `${formatPrice(selectedModel.pricing.completion)} out`,
+          formatContext(selectedModel.contextLength),
+        ].join(' · '),
+        icon: <Cpu className="h-3.5 w-3.5 text-primary" />,
+      });
+    } else if (value) {
+      // Model not in API results at all (legacy/custom)
+      options.push({
+        value,
+        label: value,
+        icon: <Cpu className="h-3.5 w-3.5 text-amber-400" />,
+      });
+    }
+  }
+
+  // Filter selectors as Select components
+  const categoryOptions: SelectOption[] = [
+    {
+      value: '',
+      label: t('settings.orCategory.allCategories', {
+        defaultValue: 'All Categories',
+      }),
+    },
+    ...availableCategories.map((cat) => ({
+      value: cat,
+      label: CATEGORY_LABEL_MAP[cat]
+        ? t(CATEGORY_LABEL_MAP[cat], { defaultValue: cat })
+        : cat.charAt(0).toUpperCase() + cat.slice(1).replace(/-/g, ' '),
+    })),
+  ];
+
+  const priceOptions: SelectOption[] = PRICE_OPTIONS.map((p) => ({
+    value: p.value,
+    label: t(p.labelKey, {
+      defaultValue:
+        p.value === 'all' ? 'All' : p.value === 'free' ? 'Free' : 'Paid',
+    }),
+  }));
+
+  const sortOptions: SelectOption[] = SORT_OPTIONS.map((s) => ({
+    value: s.value,
+    label: t(s.labelKey, {
+      defaultValue:
+        s.value === 'smart'
+          ? 'Smart Ranking'
+          : s.value === 'price-asc'
+            ? 'Cheapest First'
+            : s.value === 'price-desc'
+              ? 'Most Capable'
+              : 'Longest Context',
+    }),
+  }));
+
+  if (isLoading) {
+    return (
+      <div className={`relative ${className}`}>
+        <Select
+          options={[
+            {
+              value: '',
+              label: t('common.loading', { defaultValue: 'Loading...' }),
+            },
+          ]}
+          value=""
+          onChange={() => ({}) as unknown as Promise<void>}
+          label={label}
+          disabled
+        />
+        <Loader2 className="absolute right-10 top-1/2 h-3.5 w-3.5 -translate-y-1/2 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      {/* Model selector + info button */}
+      <div className="flex items-end gap-2 w-full!">
+        <div className="flex-1">
+          <Select
+            options={options}
+            value={value || ''}
+            onChange={onChange}
+            label={compact ? undefined : label}
+            searchable
+            searchPlaceholder={t('settings.modelFilter.searchPlaceholder', {
+              defaultValue: 'Search model...',
+            })}
+          />
+        </div>
+        {value && allModels?.find((m) => m.id === value) && (
+          <button
+            type="button"
+            onClick={() => setInfoOpen(true)}
+            className="flex h-10 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-muted/40 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title={t('settings.modelInfo.viewDetails', {
+              defaultValue: 'View model details',
+            })}
+          >
+            <Info className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Filter row */}
+      <div className={`mb-2 grid gap-2 grid-cols-1 sm:grid-cols-3`}>
+        <Select
+          options={categoryOptions}
+          value={category}
+          onChange={(v) => setCategory(v)}
+          label={
+            compact
+              ? undefined
+              : t('settings.orFilter.category', { defaultValue: 'Category' })
+          }
+          placeholder={
+            compact
+              ? t('settings.orFilter.category', { defaultValue: 'Category' })
+              : undefined
+          }
+        />
+        <Select
+          options={priceOptions}
+          value={priceFilter}
+          onChange={(v) => setPriceFilter(v as PriceFilter)}
+          label={
+            compact
+              ? undefined
+              : t('settings.orFilter.price', { defaultValue: 'Price' })
+          }
+          placeholder={
+            compact
+              ? t('settings.orFilter.price', { defaultValue: 'Price' })
+              : undefined
+          }
+        />
+        <Select
+          options={sortOptions}
+          value={sortMode}
+          onChange={(v) => setSortMode(v as SortMode)}
+          label={
+            compact
+              ? undefined
+              : t('settings.orFilter.sort', { defaultValue: 'Sort' })
+          }
+          placeholder={
+            compact
+              ? t('settings.orFilter.sort', { defaultValue: 'Sort' })
+              : undefined
+          }
+        />
+      </div>
+
+      {/* Model count indicator */}
+      <p className="mb-1 ml-1 text-[10px] text-muted-foreground">
+        {modelOptions.length}{' '}
+        {t('settings.orFilter.modelsAvailable', {
+          defaultValue: 'models available',
+        })}
+      </p>
+
+      {/* Model info modal */}
+      <ModelInfoModal
+        open={infoOpen}
+        onClose={() => setInfoOpen(false)}
+        model={allModels?.find((m) => m.id === value) ?? null}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/containers/settings/openrouter-primary-tab.tsx
+++ b/apps/web/src/containers/settings/openrouter-primary-tab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Star,
   Loader2,
@@ -14,7 +14,6 @@ import {
 import { Button, Input } from '@crypto-trader/ui';
 import { cn } from '../../lib/utils';
 import { useTranslation } from 'react-i18next';
-import { DynamicModelSelect } from './dynamic-model-select';
 
 interface OpenRouterPrimaryTabProps {
   llmKeys: Array<{
@@ -37,25 +36,7 @@ interface OpenRouterPrimaryTabProps {
   }) => void;
   onTest: (provider: string) => void;
   onDelete: (provider: string) => void;
-  onUpdateModel: (data: {
-    provider: string;
-    selectedModel: string | null;
-  }) => void;
 }
-
-// Curated ranking: best paid (by Finance rank) then best free
-const OPENROUTER_MODELS = [
-  // ── Top Paid ──
-  'anthropic/claude-sonnet-4.6',
-  'google/gemini-3-flash-preview',
-  'anthropic/claude-opus-4.6',
-  'deepseek/deepseek-v3.2',
-  'google/gemini-2.5-flash-lite',
-  // ── Top Free ──
-  'openrouter/elephant-alpha',
-  'nvidia/nemotron-3-super-120b-a12b:free',
-  'google/gemma-4-31b-it:free',
-];
 
 export function OpenRouterPrimaryTab({
   llmKeys,
@@ -68,7 +49,6 @@ export function OpenRouterPrimaryTab({
   onSave,
   onTest,
   onDelete,
-  onUpdateModel,
 }: OpenRouterPrimaryTabProps) {
   const { t } = useTranslation();
   const status = llmKeys.find((k) => k.provider === 'OPENROUTER');
@@ -76,16 +56,6 @@ export function OpenRouterPrimaryTab({
     (r) => r.provider === 'OPENROUTER',
   );
   const [apiKey, setApiKey] = useState('');
-  const [model, setModel] = useState(
-    status?.selectedModel || 'anthropic/claude-sonnet-4.6',
-  );
-
-  // Sync local model state when server data changes (e.g. after save/invalidation)
-  useEffect(() => {
-    if (status?.selectedModel) {
-      setModel(status.selectedModel);
-    }
-  }, [status?.selectedModel]);
 
   const isActive = status?.isActive ?? false;
   const manualTestFailed =
@@ -223,29 +193,12 @@ export function OpenRouterPrimaryTab({
 
           {/* Model Select */}
           {isActive ? (
-            <>
-              <DynamicModelSelect
-                provider="OPENROUTER"
-                value={model}
-                label={t('settings.openrouter.fallbackModel', {
-                  defaultValue: 'Fallback Model',
-                })}
-                onChange={(m) => {
-                  setModel(m);
-                  onUpdateModel({
-                    provider: 'OPENROUTER',
-                    selectedModel: m || null,
-                  });
-                }}
-                fallbackModels={OPENROUTER_MODELS}
-              />
-              <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-3 text-xs text-blue-400 leading-relaxed">
-                {t('settings.openrouter.fallbackModelNote', {
-                  defaultValue:
-                    'This model is used only when an agent has no specific configuration. Agents resolve their own LLM via Agent Hub Config.',
-                })}
-              </div>
-            </>
+            <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-3 text-xs text-blue-400 leading-relaxed">
+              {t('settings.openrouter.agentHubNote', {
+                defaultValue:
+                  'Models are configured per agent in Settings → AI Agents. A fallback model is auto-resolved there too.',
+              })}
+            </div>
           ) : (
             <div className="rounded-lg border border-dashed border-border bg-muted/20 p-3 text-xs text-muted-foreground italic text-center">
               {t('settings.activateProviderFirst', {
@@ -263,7 +216,7 @@ export function OpenRouterPrimaryTab({
                 onSave({
                   provider: 'OPENROUTER',
                   apiKey,
-                  selectedModel: model || null,
+                  selectedModel: status?.selectedModel || null,
                 })
               }
             >

--- a/apps/web/src/hooks/use-admin.ts
+++ b/apps/web/src/hooks/use-admin.ts
@@ -141,3 +141,48 @@ export function useToggleUserStatus() {
       toast.error(err?.message || i18n.t('toasts.userStatusError')),
   });
 }
+
+// ── Platform LLM Provider Toggle (Spec 38) ──────────────────────────────────
+
+export interface PlatformLLMProviderStatus {
+  provider: string;
+  isActive: boolean;
+  updatedAt: string;
+}
+
+export interface ToggleLLMProviderResult {
+  provider: string;
+  isActive: boolean;
+  affectedAgentConfigs: number;
+  affectedUsers: number;
+}
+
+export function useAdminLLMProviderStatus() {
+  return useQuery<PlatformLLMProviderStatus[]>({
+    queryKey: ['admin', 'llm-providers'],
+    queryFn: () => api.get('/admin/llm-providers'),
+    staleTime: 30_000,
+  });
+}
+
+export function useToggleLLMProvider() {
+  const qc = useQueryClient();
+  return useMutation<ToggleLLMProviderResult, { message?: string }, string>({
+    mutationFn: (provider: string) =>
+      api.put(`/admin/llm-providers/${provider}/toggle`, {}),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['admin', 'llm-providers'] });
+      qc.invalidateQueries({ queryKey: ['llm-provider-status'] });
+      toast.success(
+        i18n.t('admin.providerToggleSuccess', {
+          provider: data.provider,
+          state: data.isActive
+            ? i18n.t('admin.providerActive')
+            : i18n.t('admin.providerInactive'),
+        }),
+      );
+    },
+    onError: (err) =>
+      toast.error(err?.message || i18n.t('toasts.genericError')),
+  });
+}

--- a/apps/web/src/hooks/use-agent-config.ts
+++ b/apps/web/src/hooks/use-agent-config.ts
@@ -99,6 +99,7 @@ export function useApplyPreset() {
       ),
     onSuccess: (_, preset) => {
       queryClient.invalidateQueries({ queryKey: ['agents'] });
+      queryClient.invalidateQueries({ queryKey: ['user', 'llm-keys'] });
       const names: Record<AgentPresetName, string> = {
         free: t('settings.agents.presets.free'),
         optimized: t('settings.agents.presets.optimized'),
@@ -108,6 +109,31 @@ export function useApplyPreset() {
         t('settings.agents.presets.applied', {
           name: names[preset],
           defaultValue: `Preset "${names[preset]}" aplicado correctamente`,
+        }),
+      );
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || t('common.error'));
+    },
+  });
+}
+
+export function useAutoResolveFallback() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: () =>
+      api.post<{ fallbackModel: string }>(
+        '/users/me/agents/config/resolve-fallback',
+        {},
+      ),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['user', 'llm-keys'] });
+      toast.success(
+        t('settings.agents.fallback.resolved', {
+          model: data.fallbackModel,
+          defaultValue: `Fallback model set to ${data.fallbackModel}`,
         }),
       );
     },
@@ -131,12 +157,13 @@ export function useApplyAdminPreset() {
 
   return useMutation({
     mutationFn: (preset: AgentPresetName) =>
-      api.post<{ applied: string; count: number }>(
+      api.post<{ applied: string; count: number; fallbackModel?: string }>(
         `/admin/agent-configs/preset/${preset}`,
         {},
       ),
     onSuccess: (_, preset) => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'agents'] });
+      queryClient.invalidateQueries({ queryKey: ['user', 'llm-keys'] });
       const names: Record<AgentPresetName, string> = {
         free: t('settings.agents.presets.free'),
         optimized: t('settings.agents.presets.optimized'),

--- a/apps/web/src/hooks/use-chat-agent.ts
+++ b/apps/web/src/hooks/use-chat-agent.ts
@@ -11,6 +11,8 @@ export type AgentId =
 export interface RoutingEvent {
   agentId: AgentId;
   greeting?: string;
+  provider?: string;
+  model?: string;
 }
 
 export interface OrchestratingEvent {
@@ -21,6 +23,8 @@ export interface OrchestratingEvent {
 export interface UseChatAgentReturn {
   selectedAgentId: AgentId | null;
   routedAgentId: AgentId | null;
+  routedProvider: string | null;
+  routedModel: string | null;
   isOrchestrating: boolean;
   orchestratingStep: string;
   selectAgent: (agentId: AgentId | null) => void;
@@ -35,6 +39,8 @@ export function useChatAgent(
 ): UseChatAgentReturn {
   const [selectedAgentId, setSelectedAgentId] = useState<AgentId | null>(null);
   const [routedAgentId, setRoutedAgentId] = useState<AgentId | null>(null);
+  const [routedProvider, setRoutedProvider] = useState<string | null>(null);
+  const [routedModel, setRoutedModel] = useState<string | null>(null);
   const [isOrchestrating, setIsOrchestrating] = useState(false);
   const [orchestratingStep, setOrchestratingStep] = useState('');
 
@@ -52,6 +58,8 @@ export function useChatAgent(
 
   const handleRoutingEvent = useCallback((event: RoutingEvent) => {
     setRoutedAgentId(event.agentId);
+    if (event.provider) setRoutedProvider(event.provider);
+    if (event.model) setRoutedModel(event.model);
     setIsOrchestrating(false);
   }, []);
 
@@ -70,6 +78,8 @@ export function useChatAgent(
   return {
     selectedAgentId,
     routedAgentId,
+    routedProvider,
+    routedModel,
     isOrchestrating,
     orchestratingStep,
     selectAgent,

--- a/apps/web/src/hooks/use-openrouter-models.ts
+++ b/apps/web/src/hooks/use-openrouter-models.ts
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+
+export interface OpenRouterModelInfo {
+  id: string;
+  name: string;
+  contextLength: number;
+  maxCompletionTokens: number | null;
+  pricing: { prompt: number; completion: number };
+  isFree: boolean;
+  categories: string[];
+  supportedParameters: string[];
+  description?: string;
+}
+
+interface OpenRouterModelsResponse {
+  data: OpenRouterModelInfo[];
+  count: number;
+}
+
+export function useOpenRouterModels(filter?: {
+  category?: string;
+  freeOnly?: boolean;
+}) {
+  return useQuery<OpenRouterModelInfo[]>({
+    queryKey: ['openrouter-models', filter],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (filter?.category) params.set('category', filter.category);
+      if (filter?.freeOnly) params.set('freeOnly', 'true');
+      const response = await api.get<OpenRouterModelsResponse>(
+        `/openrouter/models?${params.toString()}`,
+      );
+      return response.data;
+    },
+    staleTime: 15 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+}
+
+/**
+ * Returns the top curated model IDs (paid first, then free)
+ * from the dynamically fetched OpenRouter models.
+ */
+export function useOpenRouterCuratedModels(limit = 8) {
+  const { data: models, ...rest } = useOpenRouterModels();
+
+  const curated: string[] = [];
+  if (models) {
+    // Top paid by price (most capable)
+    const paid = models
+      .filter((m) => !m.isFree)
+      .sort((a, b) => b.pricing.completion - a.pricing.completion)
+      .slice(0, 5);
+    // Top free by context length
+    const free = models
+      .filter((m) => m.isFree)
+      .sort((a, b) => b.contextLength - a.contextLength)
+      .slice(0, limit - paid.length);
+
+    curated.push(...paid.map((m) => m.id), ...free.map((m) => m.id));
+  }
+
+  return { data: curated, models, ...rest };
+}

--- a/apps/web/src/hooks/use-user.ts
+++ b/apps/web/src/hooks/use-user.ts
@@ -392,3 +392,18 @@ export function usePlatformMode() {
     isLoading,
   };
 }
+
+// ── Platform LLM Provider Status (user-facing, Spec 38) ─────────────────────
+
+export interface LLMProviderStatus {
+  provider: string;
+  isActive: boolean;
+}
+
+export function usePlatformLLMStatus() {
+  return useQuery<LLMProviderStatus[]>({
+    queryKey: ['llm-provider-status'],
+    queryFn: () => api.get('/llm-providers/status'),
+    staleTime: 60_000,
+  });
+}

--- a/apps/web/src/hooks/use-user.ts
+++ b/apps/web/src/hooks/use-user.ts
@@ -137,7 +137,9 @@ export function useTestTestnetBinanceConnection() {
         toast.success(i18n.t('toasts.testnetConnectionSuccess'));
       } else {
         toast.error(
-          i18n.t('toasts.testnetConnectionError', { error: data.error ?? 'unknown' }),
+          i18n.t('toasts.testnetConnectionError', {
+            error: data.error ?? 'unknown',
+          }),
         );
       }
     },
@@ -375,9 +377,7 @@ export function usePlatformMode() {
     if (!isLoading && mode !== 'SANDBOX' && !availableModes.includes(mode)) {
       updateMode.mutate('SANDBOX', {
         onSuccess: () => {
-          toast.warning(
-            i18n.t('toasts.modeFallback', { mode }),
-          );
+          toast.warning(i18n.t('toasts.modeFallback', { mode }));
         },
       });
     }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -92,6 +92,12 @@ async function request<T>(
     const err = await res
       .json()
       .catch(() => ({ message: 'Error en la solicitud' }));
+
+    // Spec 38: Handle LLM provider disabled (409)
+    if (res.status === 409 && err.code === 'LLM_PROVIDER_DISABLED') {
+      import('sonner').then(({ toast }) => toast.warning(err.message));
+    }
+
     const errorMessage = Array.isArray(err.message)
       ? err.message.join('\n')
       : err.message || 'Error en la solicitud';

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -504,6 +504,17 @@ const en = {
     llmSubtitle:
       'Configure default AI models and monitor provider availability across the platform',
     llmProviderStatus: 'Provider Availability',
+    // Provider Toggle (Spec 38)
+    providerStatusTitle: 'Provider Status',
+    providerStatusSubtitle:
+      'Enable or disable LLM providers platform-wide. Disabling a provider removes all user agent configurations using it.',
+    providerActive: 'Active',
+    providerInactive: 'Disabled',
+    providerToggleConfirmTitle: 'Disable Provider?',
+    providerToggleConfirmDesc:
+      'Disabling {{provider}} will delete all agent configurations using this provider. Affected users will be notified.',
+    providerToggleConfirmAction: 'Disable Provider',
+    providerToggleSuccess: '{{provider}} is now {{state}}',
     llmDefaultModels: 'Default Agent Models',
     llmDefaultModelsDesc:
       'Set the default provider and model for each AI agent. Users can override these with their own configuration.',
@@ -696,6 +707,9 @@ const en = {
       noKeyBannerTitle: 'API key required',
       noKeyBannerDesc:
         'You need to configure at least one active API key to access the platform. Add your OpenRouter key below and test the connection.',
+      providerDisabledByAdmin: 'Disabled by administrator',
+      providerDisabledOverlay:
+        'This provider has been disabled by the platform administrator.',
     },
     newsSubtitle: 'Configure news sources and API keys',
     newsSubTabs: {
@@ -1524,10 +1538,13 @@ const en = {
       CREATE_SESSION_ERROR:
         'Failed to create session. Check your API key in Settings.',
       DELETE_SESSION_ERROR: 'Failed to delete session.',
+      LLM_PROVIDER_DISABLED:
+        'This LLM provider has been disabled by the administrator.',
     },
   },
   agents: {
     selectAgent: 'Choose your agent',
+    providerNeedsAttention: 'Needs attention — provider disabled',
     tabStatus: 'Agent Status',
     tabModels: 'Default Models',
     kryptoDesc: 'Let KRYPTO decide the best agent for your question',

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -519,6 +519,8 @@ const en = {
     llmDefaultModelsDesc:
       'Set the default provider and model for each AI agent. Users can override these with their own configuration.',
     agentModelsTitle: 'Default Agent Models',
+    fallbackDescription:
+      'Default fallback model used platform-wide when a user has no custom configuration. Applied automatically by presets.',
     agentModelsSubtitle:
       'Set the default provider and model for each AI agent. Users can override these with their own configuration.',
     // Audit Log
@@ -769,8 +771,31 @@ const en = {
       free: 'Free Ranking',
       all: 'All Models',
       reasoning: 'Reasoning',
-      fast: 'Fast',
-      analytics: 'Analytics',
+      fast: 'Fast & Cheap',
+      toolUse: 'Tool Use',
+      longContext: 'Long Context (200K+)',
+      premium: 'Premium',
+      allCategories: 'All Categories',
+    },
+    orPrice: {
+      all: 'All',
+      free: 'Free Only',
+      paid: 'Paid Only',
+    },
+    orSort: {
+      smart: 'Smart Ranking',
+      cheapest: 'Cheapest First',
+      mostCapable: 'Most Capable',
+      longestContext: 'Longest Context',
+    },
+    orFilter: {
+      category: 'Category',
+      price: 'Price',
+      sort: 'Sort By',
+      modelsAvailable: 'models available',
+    },
+    modelInfo: {
+      viewDetails: 'View model details',
     },
     provider: 'Provider',
     model: 'Model',
@@ -778,6 +803,9 @@ const en = {
     active: 'Active',
     inactive: 'Inactive',
     invalid: 'Invalid',
+    disabledByAdmin: 'Disabled',
+    providerDisabledNotice:
+      'This provider has been temporarily disabled by the administrator. For more details, please contact us.',
     newsSources: 'News Sources',
     freeSource: 'Free · No API key required',
     reachable: 'Reachable',
@@ -842,6 +870,13 @@ const en = {
         applying: 'Applying preset…',
         confirm:
           'Apply the "{{name}}" preset to all agents? This will overwrite your current configuration.',
+      },
+      fallback: {
+        title: 'Fallback Model',
+        description:
+          'Safety net model used when an agent has no specific configuration. Applied automatically by presets.',
+        autoResolve: 'Auto-resolve',
+        resolved: 'Fallback model set to {{model}}',
       },
     },
   },
@@ -1559,6 +1594,7 @@ const en = {
     marketDesc: 'Market analyst — prices, indicators, technical analysis',
     blockchainDesc: 'Blockchain expert — DeFi, wallets, smart contracts',
     riskDesc: 'Risk manager — stop-loss, exposure, portfolio safety',
+    agentSwitched: 'Agent switched to {{agent}} ({{provider}}/{{model}})',
     routedByKrypto: 'Routed by KRYPTO',
     orchestrating: 'KRYPTO coordinating…',
     toolCall: 'FORGE tool request',

--- a/apps/web/src/locales/es.ts
+++ b/apps/web/src/locales/es.ts
@@ -507,6 +507,17 @@ const es = {
     llmSubtitle:
       'Configura los modelos de IA por defecto y monitorea la disponibilidad de proveedores en la plataforma',
     llmProviderStatus: 'Disponibilidad de Proveedores',
+    // Provider Toggle (Spec 38)
+    providerStatusTitle: 'Estado de Proveedores',
+    providerStatusSubtitle:
+      'Habilita o deshabilita proveedores LLM a nivel de plataforma. Deshabilitar un proveedor elimina todas las configuraciones de agentes que lo usen.',
+    providerActive: 'Activo',
+    providerInactive: 'Deshabilitado',
+    providerToggleConfirmTitle: '¿Deshabilitar Proveedor?',
+    providerToggleConfirmDesc:
+      'Deshabilitar {{provider}} eliminará todas las configuraciones de agentes que usen este proveedor. Los usuarios afectados serán notificados.',
+    providerToggleConfirmAction: 'Deshabilitar Proveedor',
+    providerToggleSuccess: '{{provider}} ahora está {{state}}',
     llmDefaultModels: 'Modelos por Defecto de Agentes',
     llmDefaultModelsDesc:
       'Establece el proveedor y modelo por defecto para cada agente de IA. Los usuarios pueden sobreescribir esto con su propia configuración.',
@@ -701,6 +712,9 @@ const es = {
       noKeyBannerTitle: 'Se requiere una clave API',
       noKeyBannerDesc:
         'Necesitas configurar al menos una clave API activa para acceder a la plataforma. Agrega tu clave de OpenRouter y prueba la conexión.',
+      providerDisabledByAdmin: 'Deshabilitado por el administrador',
+      providerDisabledOverlay:
+        'Este proveedor ha sido deshabilitado por el administrador de la plataforma.',
     },
     newsSubtitle: 'Configura fuentes de noticias y claves API',
     newsSubTabs: {
@@ -1540,10 +1554,13 @@ const es = {
       CREATE_SESSION_ERROR:
         'No se pudo crear la sesión. Revisá tu clave de API en Ajustes.',
       DELETE_SESSION_ERROR: 'No se pudo eliminar la sesión.',
+      LLM_PROVIDER_DISABLED:
+        'Este proveedor LLM ha sido deshabilitado por el administrador.',
     },
   },
   agents: {
     selectAgent: 'Elige tu agente',
+    providerNeedsAttention: 'Requiere atención — proveedor deshabilitado',
     tabStatus: 'Estado de Agentes',
     tabModels: 'Modelos por Defecto',
     kryptoDesc: 'Dejar que KRYPTO decida el mejor agente para tu pregunta',

--- a/apps/web/src/locales/es.ts
+++ b/apps/web/src/locales/es.ts
@@ -524,6 +524,8 @@ const es = {
     agentModelsTitle: 'Modelos por Defecto de Agentes',
     agentModelsSubtitle:
       'Establece el proveedor y modelo por defecto para cada agente de IA. Los usuarios pueden sobreescribir esto con su propia configuración.',
+    fallbackDescription:
+      'Modelo de respaldo por defecto usado a nivel de plataforma cuando un usuario no tiene configuración personalizada. Se aplica automáticamente con los presets.',
     // Audit Log
     auditLogTitle: 'Registro de Auditoría',
     auditLogSubtitle:
@@ -774,8 +776,31 @@ const es = {
       free: 'Ranking Gratuitos',
       all: 'Todos los Modelos',
       reasoning: 'Razonamiento',
-      fast: 'Rápidos',
-      analytics: 'Analíticos',
+      fast: 'Rápidos y Baratos',
+      toolUse: 'Uso de Herramientas',
+      longContext: 'Contexto Largo (200K+)',
+      premium: 'Premium',
+      allCategories: 'Todas las Categorías',
+    },
+    orPrice: {
+      all: 'Todos',
+      free: 'Solo Gratis',
+      paid: 'Solo Pagos',
+    },
+    orSort: {
+      smart: 'Ranking Inteligente',
+      cheapest: 'Más Baratos',
+      mostCapable: 'Más Capaces',
+      longestContext: 'Mayor Contexto',
+    },
+    orFilter: {
+      category: 'Categoría',
+      price: 'Precio',
+      sort: 'Ordenar',
+      modelsAvailable: 'modelos disponibles',
+    },
+    modelInfo: {
+      viewDetails: 'Ver detalles del modelo',
     },
     provider: 'Proveedor',
     model: 'Modelo',
@@ -783,6 +808,9 @@ const es = {
     active: 'Activo',
     inactive: 'Inactivo',
     invalid: 'Inválido',
+    disabledByAdmin: 'Deshabilitado',
+    providerDisabledNotice:
+      'Este proveedor fue desactivado temporalmente por el administrador, para conocer más detalles ponte en contacto con nosotros.',
     newsSources: 'Fuentes de Noticias',
     freeSource: 'Gratis · Sin clave API requerida',
     reachable: 'Alcanzable',
@@ -849,6 +877,13 @@ const es = {
         applying: 'Aplicando preset…',
         confirm:
           '¿Aplicar el preset "{{name}}" a todos los agentes? Esto sobreescribirá tu configuración actual.',
+      },
+      fallback: {
+        title: 'Modelo Fallback',
+        description:
+          'Modelo de respaldo usado cuando un agente no tiene configuración específica. Se aplica automáticamente con los presets.',
+        autoResolve: 'Auto-resolver',
+        resolved: 'Modelo fallback configurado: {{model}}',
       },
     },
   },
@@ -1581,6 +1616,7 @@ const es = {
     blockchainDesc: 'Experto en blockchain — DeFi, wallets, smart contracts',
     riskDesc:
       'Gestor de riesgo — stop-loss, exposición, seguridad del portafolio',
+    agentSwitched: 'Agente cambiado a {{agent}} ({{provider}}/{{model}})',
     routedByKrypto: 'Enrutado por KRYPTO',
     orchestrating: 'KRYPTO coordinando…',
     toolCall: 'Solicitud de herramienta FORGE',

--- a/apps/web/src/pages/admin/llm-providers.tsx
+++ b/apps/web/src/pages/admin/llm-providers.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { ProviderStatusGrid } from '../../containers/settings/provider-status-grid';
 import { OpenRouterPrimaryTab } from '../../containers/settings/openrouter-primary-tab';
 import { DynamicModelSelect } from '../../containers/settings/dynamic-model-select';
+import { AdminProviderStatusPanel } from '../../containers/admin/admin-provider-status-panel';
 import {
   useLLMKeys,
   useSetLLMKey,
@@ -151,6 +152,9 @@ export function AdminLLMProvidersPage() {
           </div>
         </div>
       )}
+
+      {/* Provider Status Toggle (Spec 38) */}
+      <AdminProviderStatusPanel />
 
       {/* API Keys Section */}
       <div className="rounded-xl border border-border bg-card p-5">

--- a/apps/web/src/pages/admin/llm-providers.tsx
+++ b/apps/web/src/pages/admin/llm-providers.tsx
@@ -9,6 +9,9 @@ import {
   ExternalLink,
   Trash2,
   AlertTriangle,
+  Ban,
+  ToggleLeft,
+  Activity,
 } from 'lucide-react';
 import { Button, Input } from '@crypto-trader/ui';
 import { cn } from '../../lib/utils';
@@ -24,6 +27,7 @@ import {
   useUpdateLLMModel,
   useTestLLMKey,
   useValidateAllLLMKeys,
+  usePlatformLLMStatus,
 } from '../../hooks/use-user';
 
 const LLM_PROVIDERS = [
@@ -84,13 +88,14 @@ const LLM_PROVIDERS = [
   },
 ];
 
-type KeySubTab = 'primary' | 'providers';
+type AdminLLMTab = 'primary' | 'providers' | 'status' | 'availability';
 
 export function AdminLLMProvidersPage() {
   const { t } = useTranslation();
-  const [keySubTab, setKeySubTab] = useState<KeySubTab>('primary');
+  const [activeTab, setActiveTab] = useState<AdminLLMTab>('primary');
 
   const { data: llmKeys = [] } = useLLMKeys();
+  const { data: platformStatus = [] } = usePlatformLLMStatus();
   const hasActiveKey = llmKeys.some((k) => k.isActive);
   const { mutate: saveLLMKey, isPending: savingLLM } = useSetLLMKey();
   const { mutate: deleteLLMKey } = useDeleteLLMKey();
@@ -153,46 +158,51 @@ export function AdminLLMProvidersPage() {
         </div>
       )}
 
-      {/* Provider Status Toggle (Spec 38) */}
-      <AdminProviderStatusPanel />
-
-      {/* API Keys Section */}
-      <div className="rounded-xl border border-border bg-card p-5">
-        <h2 className="mb-4 font-semibold flex items-center gap-2">
-          <Key className="h-4 w-4 text-primary" />
-          {t('admin.llmApiKeys')}
-        </h2>
-
-        {/* Sub-tab nav */}
-        <div className="mb-4 flex gap-1 rounded-xl border border-border bg-muted/40 p-1">
+      {/* Top-level tab nav */}
+      <div className="flex gap-1 rounded-xl border border-border bg-muted/40 p-1">
+        {(
+          [
+            {
+              key: 'primary',
+              icon: Star,
+              label: t('settings.aiSubTabs.primary'),
+            },
+            {
+              key: 'providers',
+              icon: Key,
+              label: t('settings.aiSubTabs.providers'),
+            },
+            {
+              key: 'status',
+              icon: ToggleLeft,
+              label: t('admin.providerStatusTitle'),
+            },
+            {
+              key: 'availability',
+              icon: Activity,
+              label: t('admin.llmProviderStatus'),
+            },
+          ] as const
+        ).map((tab) => (
           <button
-            onClick={() => setKeySubTab('primary')}
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
             className={cn(
               'flex flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-all',
-              keySubTab === 'primary'
+              activeTab === tab.key
                 ? 'bg-card text-foreground shadow-sm'
                 : 'text-muted-foreground hover:text-foreground',
             )}
           >
-            <Star className="h-4 w-4" />
-            {t('settings.aiSubTabs.primary')}
+            <tab.icon className="h-4 w-4" />
+            {tab.label}
           </button>
-          <button
-            onClick={() => setKeySubTab('providers')}
-            className={cn(
-              'flex flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-all',
-              keySubTab === 'providers'
-                ? 'bg-card text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-            )}
-          >
-            <Key className="h-4 w-4" />
-            {t('settings.aiSubTabs.providers')}
-          </button>
-        </div>
+        ))}
+      </div>
 
-        {/* Primary Provider (OpenRouter) */}
-        {keySubTab === 'primary' && (
+      {/* Primary Provider (OpenRouter) */}
+      {activeTab === 'primary' && (
+        <div className="rounded-xl border border-border bg-card p-5">
           <OpenRouterPrimaryTab
             llmKeys={llmKeys}
             llmValidation={llmValidation}
@@ -206,249 +216,280 @@ export function AdminLLMProvidersPage() {
             }
             onTest={(provider) => testLLM(provider)}
             onDelete={(provider) => deleteLLMKey(provider)}
-            onUpdateModel={(data) => updateLLMModel(data)}
           />
-        )}
+        </div>
+      )}
 
-        {/* Other Providers */}
-        {keySubTab === 'providers' && (
-          <>
-            <div className="mb-4 flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <BotMessageSquare className="h-4 w-4 text-primary" />
-                <span className="font-semibold text-sm">
-                  {t('settings.llmKeys')}
+      {/* Other Providers */}
+      {activeTab === 'providers' && (
+        <div className="rounded-xl border border-border bg-card p-5">
+          <div className="mb-4 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <BotMessageSquare className="h-4 w-4 text-primary" />
+              <span className="font-semibold text-sm">
+                {t('settings.llmKeys')}
+              </span>
+              {llmValidation && (
+                <span
+                  className={cn(
+                    'rounded-full px-2 py-0.5 text-xs font-semibold',
+                    llmValidation.active > 0
+                      ? 'bg-emerald-500/10 text-emerald-500'
+                      : 'bg-red-500/10 text-red-500',
+                  )}
+                >
+                  {llmValidation.active}/{llmValidation.total}{' '}
+                  {t('settings.available')}
                 </span>
-                {llmValidation && (
-                  <span
-                    className={cn(
-                      'rounded-full px-2 py-0.5 text-xs font-semibold',
-                      llmValidation.active > 0
-                        ? 'bg-emerald-500/10 text-emerald-500'
-                        : 'bg-red-500/10 text-red-500',
-                    )}
-                  >
-                    {llmValidation.active}/{llmValidation.total}{' '}
-                    {t('settings.available')}
-                  </span>
-                )}
-              </div>
-              <Button
-                size="sm"
-                variant="ghost"
-                disabled={validatingLLMKeys}
-                onClick={() => revalidateLLMKeys()}
-              >
-                {validatingLLMKeys ? (
-                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                ) : (
-                  <RefreshCw className="mr-1 h-3 w-3" />
-                )}
-                {validatingLLMKeys
-                  ? t('settings.validating')
-                  : t('settings.revalidate')}
-              </Button>
+              )}
             </div>
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {LLM_PROVIDERS.map((provider) => {
-                const status = getLLMKeyStatus(provider.value);
-                const form = getLLMForm(provider.value);
-                const validation = llmValidation?.results.find(
-                  (r) => r.provider === provider.value,
-                );
-                const manualTestFailed =
-                  status?.isActive &&
-                  llmTestResult &&
-                  llmTestProvider === provider.value &&
-                  !llmTestResult.connected;
-                const resolvedStatus = manualTestFailed
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={validatingLLMKeys}
+              onClick={() => revalidateLLMKeys()}
+            >
+              {validatingLLMKeys ? (
+                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-1 h-3 w-3" />
+              )}
+              {validatingLLMKeys
+                ? t('settings.validating')
+                : t('settings.revalidate')}
+            </Button>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {LLM_PROVIDERS.map((provider) => {
+              const status = getLLMKeyStatus(provider.value);
+              const form = getLLMForm(provider.value);
+              const validation = llmValidation?.results.find(
+                (r) => r.provider === provider.value,
+              );
+              const platformProvider = platformStatus.find(
+                (p) => p.provider === provider.value,
+              );
+              const isDisabledByAdmin = platformProvider?.isActive === false;
+              const manualTestFailed =
+                status?.isActive &&
+                llmTestResult &&
+                llmTestProvider === provider.value &&
+                !llmTestResult.connected;
+              const resolvedStatus = isDisabledByAdmin
+                ? 'DISABLED'
+                : manualTestFailed
                   ? 'INVALID'
                   : (validation?.status ??
                     (status?.isActive ? 'ACTIVE' : 'INACTIVE'));
-                return (
-                  <div
-                    key={provider.value}
-                    className="rounded-lg border border-border p-4"
-                  >
-                    <div className="mb-3 flex items-center justify-between">
-                      <span className="font-medium text-sm">
-                        {provider.label}
+              return (
+                <div
+                  key={provider.value}
+                  className={cn(
+                    'rounded-lg border p-4',
+                    isDisabledByAdmin
+                      ? 'border-red-500/20 bg-red-500/5 opacity-70'
+                      : 'border-border',
+                  )}
+                >
+                  <div className="mb-3 flex items-center justify-between">
+                    <span className="font-medium text-sm">
+                      {provider.label}
+                    </span>
+                    {isDisabledByAdmin ? (
+                      <span className="flex items-center gap-1.5 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-semibold text-red-400">
+                        <Ban className="h-3 w-3" />
+                        {t('settings.disabledByAdmin', {
+                          defaultValue: 'Disabled',
+                        })}
                       </span>
-                      {validatingLLMKeys && status?.isActive ? (
-                        <span className="flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-semibold text-amber-500">
-                          <Loader2 className="h-3 w-3 animate-spin" />
-                          {t('settings.validating')}
-                        </span>
-                      ) : (
-                        <span
-                          className={cn(
-                            'rounded-full px-2 py-0.5 text-xs font-semibold',
-                            resolvedStatus === 'ACTIVE'
-                              ? 'bg-emerald-500/10 text-emerald-500'
-                              : resolvedStatus === 'INVALID'
-                                ? 'bg-red-500/10 text-red-500'
-                                : 'bg-muted text-muted-foreground',
-                          )}
-                        >
-                          {resolvedStatus === 'ACTIVE'
-                            ? t('settings.active')
+                    ) : validatingLLMKeys && status?.isActive ? (
+                      <span className="flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-semibold text-amber-500">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        {t('settings.validating')}
+                      </span>
+                    ) : (
+                      <span
+                        className={cn(
+                          'rounded-full px-2 py-0.5 text-xs font-semibold',
+                          resolvedStatus === 'ACTIVE'
+                            ? 'bg-emerald-500/10 text-emerald-500'
                             : resolvedStatus === 'INVALID'
-                              ? t('settings.invalid')
-                              : t('settings.inactive')}
-                        </span>
-                      )}
-                    </div>
-                    <div className="grid gap-3">
-                      <div>
-                        <label className="mb-1 block text-xs font-medium">
-                          API Key
-                        </label>
-                        <Input
-                          type="password"
-                          placeholder="sk-..."
-                          value={form.apiKey}
-                          onChange={(e) =>
-                            setLlmForms((f) => ({
-                              ...f,
-                              [provider.value]: {
-                                ...(f[provider.value] ?? {
-                                  model: provider.models[0],
-                                }),
-                                apiKey: e.target.value,
-                              },
-                            }))
-                          }
-                          className="px-2 py-2"
-                        />
-                        <p className="mt-1.5 text-xs text-muted-foreground">
-                          {t('settings.getApiKeyAt')}{' '}
-                          <a
-                            href={provider.helpLink}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 text-primary hover:underline font-medium"
-                          >
-                            {provider.helpLinkText}
-                            <ExternalLink className="h-3 w-3" />
-                          </a>
-                        </p>
-                      </div>
-                      {status?.isActive ? (
-                        <DynamicModelSelect
-                          provider={provider.value}
-                          value={form.model}
-                          label={t('settings.model')}
-                          onChange={(model) => {
-                            setLlmForms((f) => ({
-                              ...f,
-                              [provider.value]: {
-                                ...(f[provider.value] ?? { apiKey: '' }),
-                                model,
-                              },
-                            }));
-                            updateLLMModel({
-                              provider: provider.value,
-                              selectedModel: model || null,
-                            });
-                          }}
-                          fallbackModels={provider.models}
-                        />
-                      ) : (
-                        <div className="rounded-lg border border-dashed border-border bg-muted/20 p-3 text-xs text-muted-foreground italic text-center">
-                          {t('settings.activateProviderFirst')}
-                        </div>
-                      )}
-                    </div>
-                    <div className="mt-3 flex flex-wrap items-center gap-2">
-                      <Button
-                        size="sm"
-                        disabled={savingLLM || !form.apiKey}
-                        onClick={() =>
-                          saveLLMKey(
-                            {
-                              provider: provider.value,
-                              apiKey: form.apiKey,
-                              selectedModel: form.model || null,
-                            },
-                            {
-                              onSuccess: () => {
-                                setLlmForms((f) => ({
-                                  ...f,
-                                  [provider.value]: {
-                                    apiKey: '',
-                                    model: '',
-                                  },
-                                }));
-                                resetLLMTest();
-                              },
-                            },
-                          )
-                        }
-                      >
-                        {savingLLM && (
-                          <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                              ? 'bg-red-500/10 text-red-500'
+                              : 'bg-muted text-muted-foreground',
                         )}
-                        {t('common.save')}
-                      </Button>
-                      {status?.isActive && (
-                        <>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            disabled={testingLLM}
-                            onClick={() => testLLM(provider.value)}
-                          >
-                            {testingLLM &&
-                              llmTestProvider === provider.value && (
-                                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                              )}
-                            {testingLLM && llmTestProvider === provider.value
-                              ? t('settings.testing')
-                              : t('settings.testConnection')}
-                          </Button>
-                          {llmTestResult &&
-                            llmTestProvider === provider.value && (
-                              <span
-                                className={cn(
-                                  'text-xs font-medium',
-                                  llmTestResult.connected
-                                    ? 'text-emerald-500'
-                                    : 'text-red-500',
-                                )}
-                              >
-                                {llmTestResult.connected
-                                  ? t('settings.testSuccess')
-                                  : `${t('settings.testFailed')}: ${llmTestResult.error}`}
-                              </span>
-                            )}
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="gap-1.5 text-red-500 hover:text-red-600"
-                            onClick={() => deleteLLMKey(provider.value)}
-                          >
-                            <Trash2 className="h-3 w-3" />
-                            {t('settings.remove')}
-                          </Button>
-                        </>
-                      )}
-                    </div>
+                      >
+                        {resolvedStatus === 'ACTIVE'
+                          ? t('settings.active')
+                          : resolvedStatus === 'INVALID'
+                            ? t('settings.invalid')
+                            : t('settings.inactive')}
+                      </span>
+                    )}
                   </div>
-                );
-              })}
-            </div>
-          </>
-        )}
-      </div>
 
-      {/* Provider Status */}
-      <div className="rounded-xl border border-border bg-card p-5">
-        <h2 className="mb-4 font-semibold flex items-center gap-2">
-          <Shield className="h-4 w-4 text-primary" />
-          {t('admin.llmProviderStatus')}
-        </h2>
-        <ProviderStatusGrid />
-      </div>
+                  {isDisabledByAdmin ? (
+                    <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-xs text-red-400 leading-relaxed">
+                      <Ban className="inline h-3 w-3 mr-1 -mt-0.5" />
+                      {t('settings.providerDisabledNotice', {
+                        defaultValue:
+                          'This provider has been temporarily disabled by the administrator. For more details, please contact us.',
+                      })}
+                    </div>
+                  ) : (
+                    <>
+                      <div className="grid gap-3">
+                        <div>
+                          <label className="mb-1 block text-xs font-medium">
+                            API Key
+                          </label>
+                          <Input
+                            type="password"
+                            placeholder="sk-..."
+                            value={form.apiKey}
+                            onChange={(e) =>
+                              setLlmForms((f) => ({
+                                ...f,
+                                [provider.value]: {
+                                  ...(f[provider.value] ?? {
+                                    model: provider.models[0],
+                                  }),
+                                  apiKey: e.target.value,
+                                },
+                              }))
+                            }
+                            className="px-2 py-2"
+                          />
+                          <p className="mt-1.5 text-xs text-muted-foreground">
+                            {t('settings.getApiKeyAt')}{' '}
+                            <a
+                              href={provider.helpLink}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center gap-1 text-primary hover:underline font-medium"
+                            >
+                              {provider.helpLinkText}
+                              <ExternalLink className="h-3 w-3" />
+                            </a>
+                          </p>
+                        </div>
+                        {status?.isActive ? (
+                          <DynamicModelSelect
+                            provider={provider.value}
+                            value={form.model}
+                            label={t('settings.model')}
+                            onChange={(model) => {
+                              setLlmForms((f) => ({
+                                ...f,
+                                [provider.value]: {
+                                  ...(f[provider.value] ?? { apiKey: '' }),
+                                  model,
+                                },
+                              }));
+                              updateLLMModel({
+                                provider: provider.value,
+                                selectedModel: model || null,
+                              });
+                            }}
+                            fallbackModels={provider.models}
+                          />
+                        ) : (
+                          <div className="rounded-lg border border-dashed border-border bg-muted/20 p-3 text-xs text-muted-foreground italic text-center">
+                            {t('settings.activateProviderFirst')}
+                          </div>
+                        )}
+                      </div>
+                      <div className="mt-3 flex flex-wrap items-center gap-2">
+                        <Button
+                          size="sm"
+                          disabled={savingLLM || !form.apiKey}
+                          onClick={() =>
+                            saveLLMKey(
+                              {
+                                provider: provider.value,
+                                apiKey: form.apiKey,
+                                selectedModel: form.model || null,
+                              },
+                              {
+                                onSuccess: () => {
+                                  setLlmForms((f) => ({
+                                    ...f,
+                                    [provider.value]: {
+                                      apiKey: '',
+                                      model: '',
+                                    },
+                                  }));
+                                  resetLLMTest();
+                                },
+                              },
+                            )
+                          }
+                        >
+                          {savingLLM && (
+                            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                          )}
+                          {t('common.save')}
+                        </Button>
+                        {status?.isActive && (
+                          <>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              disabled={testingLLM}
+                              onClick={() => testLLM(provider.value)}
+                            >
+                              {testingLLM &&
+                                llmTestProvider === provider.value && (
+                                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                                )}
+                              {testingLLM && llmTestProvider === provider.value
+                                ? t('settings.testing')
+                                : t('settings.testConnection')}
+                            </Button>
+                            {llmTestResult &&
+                              llmTestProvider === provider.value && (
+                                <span
+                                  className={cn(
+                                    'text-xs font-medium',
+                                    llmTestResult.connected
+                                      ? 'text-emerald-500'
+                                      : 'text-red-500',
+                                  )}
+                                >
+                                  {llmTestResult.connected
+                                    ? t('settings.testSuccess')
+                                    : `${t('settings.testFailed')}: ${llmTestResult.error}`}
+                                </span>
+                              )}
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="gap-1.5 text-red-500 hover:text-red-600"
+                              onClick={() => deleteLLMKey(provider.value)}
+                            >
+                              <Trash2 className="h-3 w-3" />
+                              {t('settings.remove')}
+                            </Button>
+                          </>
+                        )}
+                      </div>
+                    </>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Provider Status Toggle */}
+      {activeTab === 'status' && <AdminProviderStatusPanel />}
+
+      {/* Provider Availability */}
+      {activeTab === 'availability' && (
+        <div className="rounded-xl border border-border bg-card p-5">
+          <ProviderStatusGrid />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/dashboard/bot-analysis.tsx
+++ b/apps/web/src/pages/dashboard/bot-analysis.tsx
@@ -23,7 +23,6 @@ import {
   AgentInputSummary,
   CombinedScoreBanner,
   NextDecisionBanner,
-  AI_VALID_MS,
   type NewsAnalysisData,
   type SigmaSentiment,
 } from '../../components/bot-analysis';
@@ -108,10 +107,7 @@ export function BotAnalysisPage() {
 
   const { data: pageNewsConfig } = useNewsConfig();
   const { data: pageAnalysis } = useNewsAnalysis();
-  const pageHasAi = !!(
-    pageAnalysis?.aiAnalyzedAt &&
-    Date.now() - new Date(pageAnalysis.aiAnalyzedAt).getTime() < AI_VALID_MS
-  );
+  const pageHasAi = !!pageAnalysis?.aiAnalyzedAt;
   const newsAnalysisData: NewsAnalysisData = {
     positive: pageHasAi
       ? (pageAnalysis?.aiPositiveCount ?? 0)

--- a/apps/web/src/pages/dashboard/news-feed.tsx
+++ b/apps/web/src/pages/dashboard/news-feed.tsx
@@ -65,11 +65,7 @@ export function NewsFeedPage() {
   })();
 
   // Build AI overlay map from persisted analysis
-  const AI_VALID_MS = 12 * 60 * 60 * 1000;
-  const hasValidAi = !!(
-    analysis?.aiAnalyzedAt &&
-    Date.now() - new Date(analysis.aiAnalyzedAt).getTime() < AI_VALID_MS
-  );
+  const hasValidAi = !!analysis?.aiAnalyzedAt;
   const aiMap = new Map((analysis?.aiHeadlines ?? []).map((a) => [a.id, a]));
 
   const effectiveNews = news.map((n) => ({

--- a/apps/web/src/pages/dashboard/settings.tsx
+++ b/apps/web/src/pages/dashboard/settings.tsx
@@ -16,6 +16,7 @@ import {
   TableConfig,
   BarChart3,
   Star,
+  Ban,
 } from 'lucide-react';
 import { Button, InfoTooltip, Input } from '@crypto-trader/ui';
 import { cn } from '../../lib/utils';
@@ -40,6 +41,7 @@ import {
   useTestBinanceConnection,
   useTestLLMKey,
   useValidateAllLLMKeys,
+  usePlatformLLMStatus,
   useNewsSourcesStatus,
   useNewsApiKeys,
   useSetNewsApiKey,
@@ -113,16 +115,7 @@ const LLM_PROVIDERS = [
   {
     value: 'OPENROUTER',
     label: 'OpenRouter',
-    models: [
-      'anthropic/claude-sonnet-4.6',
-      'google/gemini-3-flash-preview',
-      'anthropic/claude-opus-4.6',
-      'deepseek/deepseek-v3.2',
-      'google/gemini-2.5-flash-lite',
-      'openrouter/elephant-alpha',
-      'nvidia/nemotron-3-super-120b-a12b:free',
-      'google/gemma-4-31b-it:free',
-    ],
+    models: [], // Resolved dynamically via useOpenRouterModels hook
     helpLink: 'https://openrouter.ai/keys',
     helpLinkText: 'openrouter.ai',
   },
@@ -181,6 +174,7 @@ export function SettingsPage() {
 
   // LLM Keys
   const { data: llmKeys = [] } = useLLMKeys();
+  const { data: platformStatus = [] } = usePlatformLLMStatus();
   const { mutate: saveLLMKey, isPending: savingLLM } = useSetLLMKey();
   const { mutate: deleteLLMKey } = useDeleteLLMKey();
   const { mutate: updateLLMModel } = useUpdateLLMModel();
@@ -752,7 +746,6 @@ export function SettingsPage() {
                 }
                 onTest={(provider) => testLLM(provider)}
                 onDelete={(provider) => deleteLLMKey(provider)}
-                onUpdateModel={(data) => updateLLMModel(data)}
               />
             )}
 
@@ -822,26 +815,45 @@ export function SettingsPage() {
                         const validation = llmValidation?.results.find(
                           (r) => r.provider === provider.value,
                         );
+                        const platformProvider = platformStatus.find(
+                          (p) => p.provider === provider.value,
+                        );
+                        const isDisabledByAdmin =
+                          platformProvider?.isActive === false;
                         // Priority: manual test > auto-validation > DB isActive flag
                         const manualTestFailed =
                           status?.isActive &&
                           llmTestResult &&
                           llmTestProvider === provider.value &&
                           !llmTestResult.connected;
-                        const resolvedStatus = manualTestFailed
-                          ? 'INVALID'
-                          : (validation?.status ??
-                            (status?.isActive ? 'ACTIVE' : 'INACTIVE'));
+                        const resolvedStatus = isDisabledByAdmin
+                          ? 'DISABLED'
+                          : manualTestFailed
+                            ? 'INVALID'
+                            : (validation?.status ??
+                              (status?.isActive ? 'ACTIVE' : 'INACTIVE'));
                         return (
                           <div
                             key={provider.value}
-                            className="rounded-lg border border-border p-4"
+                            className={cn(
+                              'rounded-lg border p-4',
+                              isDisabledByAdmin
+                                ? 'border-red-500/20 bg-red-500/5 opacity-70'
+                                : 'border-border',
+                            )}
                           >
                             <div className="mb-3 flex items-center justify-between">
                               <span className="font-medium text-sm">
                                 {provider.label}
                               </span>
-                              {validatingLLMKeys && status?.isActive ? (
+                              {isDisabledByAdmin ? (
+                                <span className="flex items-center gap-1.5 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-semibold text-red-400">
+                                  <Ban className="h-3 w-3" />
+                                  {t('settings.disabledByAdmin', {
+                                    defaultValue: 'Disabled',
+                                  })}
+                                </span>
+                              ) : validatingLLMKeys && status?.isActive ? (
                                 <span className="flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-semibold text-amber-500">
                                   <Loader2 className="h-3 w-3 animate-spin" />
                                   {t('settings.validating')}
@@ -865,160 +877,176 @@ export function SettingsPage() {
                                 </span>
                               )}
                             </div>
-                            <div className="grid gap-3 sm:grid-cols-1">
-                              <div>
-                                <label className="mb-1 block text-xs font-medium">
-                                  API Key
-                                </label>
-                                <Input
-                                  type="password"
-                                  placeholder="sk-..."
-                                  value={form.apiKey}
-                                  onChange={(e) =>
-                                    setLlmForms((f) => ({
-                                      ...f,
-                                      [provider.value]: {
-                                        ...(f[provider.value] ?? {
-                                          model: provider.models[0],
-                                        }),
-                                        apiKey: e.target.value,
-                                      },
-                                    }))
-                                  }
-                                  className="px-2 py-2"
-                                />
-                                <p className="mt-1.5 text-xs text-muted-foreground">
-                                  {t('settings.getApiKeyAt')}{' '}
-                                  <a
-                                    href={provider.helpLink}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="inline-flex items-center gap-1 text-primary hover:underline font-medium"
-                                  >
-                                    {provider.helpLinkText}
-                                    <ExternalLink className="h-3 w-3" />
-                                  </a>
-                                </p>
+
+                            {isDisabledByAdmin ? (
+                              <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-xs text-red-400 leading-relaxed">
+                                <Ban className="inline h-3 w-3 mr-1 -mt-0.5" />
+                                {t('settings.providerDisabledNotice', {
+                                  defaultValue:
+                                    'This provider has been temporarily disabled by the administrator. For more details, please contact us.',
+                                })}
                               </div>
-                              {status?.isActive ? (
-                                <div>
-                                  <DynamicModelSelect
-                                    provider={provider.value}
-                                    value={form.model}
-                                    label={t('settings.model')}
-                                    onChange={(model) => {
-                                      setLlmForms((f) => ({
-                                        ...f,
-                                        [provider.value]: {
-                                          ...(f[provider.value] ?? {
-                                            apiKey: '',
-                                          }),
-                                          model,
-                                        },
-                                      }));
-                                      updateLLMModel({
-                                        provider: provider.value,
-                                        selectedModel: model || null,
-                                      });
-                                    }}
-                                    fallbackModels={provider.models}
-                                  />
-                                </div>
-                              ) : (
-                                <div className="mt-2 rounded-lg border border-dashed border-border bg-muted/20 p-3 text-xs text-muted-foreground italic text-center">
-                                  {t('settings.activateProviderFirst', {
-                                    defaultValue:
-                                      'Guarda tu API key para seleccionar un modelo',
-                                  })}
-                                </div>
-                              )}
-                            </div>
-                            <div className="mt-3 flex flex-wrap items-center gap-2">
-                              <Button
-                                size="sm"
-                                disabled={savingLLM || !form.apiKey}
-                                onClick={() =>
-                                  saveLLMKey(
-                                    {
-                                      provider: provider.value,
-                                      apiKey: form.apiKey,
-                                      selectedModel: form.model || null,
-                                    },
-                                    {
-                                      onSuccess: () => {
+                            ) : (
+                              <>
+                                <div className="grid gap-3 sm:grid-cols-1">
+                                  <div>
+                                    <label className="mb-1 block text-xs font-medium">
+                                      API Key
+                                    </label>
+                                    <Input
+                                      type="password"
+                                      placeholder="sk-..."
+                                      value={form.apiKey}
+                                      onChange={(e) =>
                                         setLlmForms((f) => ({
                                           ...f,
                                           [provider.value]: {
-                                            apiKey: '',
-                                            model: '',
+                                            ...(f[provider.value] ?? {
+                                              model: provider.models[0],
+                                            }),
+                                            apiKey: e.target.value,
                                           },
-                                        }));
-                                        resetLLMTest();
-                                      },
-                                    },
-                                  )
-                                }
-                              >
-                                {savingLLM && (
-                                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                                )}
-                                {t('common.save')}
-                              </Button>
-                              {status?.isActive && (
-                                <>
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    disabled={testingLLM}
-                                    onClick={() => testLLM(provider.value)}
-                                  >
-                                    {testingLLM &&
-                                      llmTestProvider === provider.value && (
-                                        <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                                      )}
-                                    {testingLLM &&
-                                    llmTestProvider === provider.value
-                                      ? t('settings.testing')
-                                      : t('settings.testConnection')}
-                                  </Button>
-                                  {llmTestResult &&
-                                    llmTestProvider === provider.value && (
-                                      <span
-                                        className={cn(
-                                          'text-xs font-medium',
-                                          llmTestResult.connected
-                                            ? 'text-emerald-500'
-                                            : 'text-red-500',
-                                        )}
+                                        }))
+                                      }
+                                      className="px-2 py-2"
+                                    />
+                                    <p className="mt-1.5 text-xs text-muted-foreground">
+                                      {t('settings.getApiKeyAt')}{' '}
+                                      <a
+                                        href={provider.helpLink}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="inline-flex items-center gap-1 text-primary hover:underline font-medium"
                                       >
-                                        {llmTestResult.connected
-                                          ? t('settings.testSuccess')
-                                          : `${t('settings.testFailed')}: ${llmTestResult.error}`}
-                                      </span>
-                                    )}
-                                  {validation?.status === 'INVALID' &&
-                                    validation.error &&
-                                    !(
-                                      llmTestResult &&
-                                      llmTestProvider === provider.value
-                                    ) && (
-                                      <span className="text-xs font-medium text-red-500">
-                                        {t('settings.autoValidationFailed')}:{' '}
-                                        {validation.error}
-                                      </span>
-                                    )}
+                                        {provider.helpLinkText}
+                                        <ExternalLink className="h-3 w-3" />
+                                      </a>
+                                    </p>
+                                  </div>
+                                  {status?.isActive ? (
+                                    <div>
+                                      <DynamicModelSelect
+                                        provider={provider.value}
+                                        value={form.model}
+                                        label={t('settings.model')}
+                                        onChange={(model) => {
+                                          setLlmForms((f) => ({
+                                            ...f,
+                                            [provider.value]: {
+                                              ...(f[provider.value] ?? {
+                                                apiKey: '',
+                                              }),
+                                              model,
+                                            },
+                                          }));
+                                          updateLLMModel({
+                                            provider: provider.value,
+                                            selectedModel: model || null,
+                                          });
+                                        }}
+                                        fallbackModels={provider.models}
+                                      />
+                                    </div>
+                                  ) : (
+                                    <div className="mt-2 rounded-lg border border-dashed border-border bg-muted/20 p-3 text-xs text-muted-foreground italic text-center">
+                                      {t('settings.activateProviderFirst', {
+                                        defaultValue:
+                                          'Guarda tu API key para seleccionar un modelo',
+                                      })}
+                                    </div>
+                                  )}
+                                </div>
+                                <div className="mt-3 flex flex-wrap items-center gap-2">
                                   <Button
                                     size="sm"
-                                    variant="ghost"
-                                    className="gap-1.5 text-red-500 hover:text-red-600"
-                                    onClick={() => deleteLLMKey(provider.value)}
+                                    disabled={savingLLM || !form.apiKey}
+                                    onClick={() =>
+                                      saveLLMKey(
+                                        {
+                                          provider: provider.value,
+                                          apiKey: form.apiKey,
+                                          selectedModel: form.model || null,
+                                        },
+                                        {
+                                          onSuccess: () => {
+                                            setLlmForms((f) => ({
+                                              ...f,
+                                              [provider.value]: {
+                                                apiKey: '',
+                                                model: '',
+                                              },
+                                            }));
+                                            resetLLMTest();
+                                          },
+                                        },
+                                      )
+                                    }
                                   >
-                                    <Trash2 className="h-3 w-3" />
-                                    {t('settings.remove')}
+                                    {savingLLM && (
+                                      <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                                    )}
+                                    {t('common.save')}
                                   </Button>
-                                </>
-                              )}
-                            </div>
+                                  {status?.isActive && (
+                                    <>
+                                      <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        disabled={testingLLM}
+                                        onClick={() => testLLM(provider.value)}
+                                      >
+                                        {testingLLM &&
+                                          llmTestProvider ===
+                                            provider.value && (
+                                            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                                          )}
+                                        {testingLLM &&
+                                        llmTestProvider === provider.value
+                                          ? t('settings.testing')
+                                          : t('settings.testConnection')}
+                                      </Button>
+                                      {llmTestResult &&
+                                        llmTestProvider === provider.value && (
+                                          <span
+                                            className={cn(
+                                              'text-xs font-medium',
+                                              llmTestResult.connected
+                                                ? 'text-emerald-500'
+                                                : 'text-red-500',
+                                            )}
+                                          >
+                                            {llmTestResult.connected
+                                              ? t('settings.testSuccess')
+                                              : `${t('settings.testFailed')}: ${llmTestResult.error}`}
+                                          </span>
+                                        )}
+                                      {validation?.status === 'INVALID' &&
+                                        validation.error &&
+                                        !(
+                                          llmTestResult &&
+                                          llmTestProvider === provider.value
+                                        ) && (
+                                          <span className="text-xs font-medium text-red-500">
+                                            {t('settings.autoValidationFailed')}
+                                            : {validation.error}
+                                          </span>
+                                        )}
+                                      <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        className="gap-1.5 text-red-500 hover:text-red-600"
+                                        onClick={() =>
+                                          deleteLLMKey(provider.value)
+                                        }
+                                      >
+                                        <Trash2 className="h-3 w-3" />
+                                        {t('settings.remove')}
+                                      </Button>
+                                    </>
+                                  )}
+                                </div>
+                              </>
+                            )}
                           </div>
                         );
                       },

--- a/apps/web/src/pages/dashboard/settings/agents.tsx
+++ b/apps/web/src/pages/dashboard/settings/agents.tsx
@@ -7,21 +7,31 @@ import {
   Zap,
   DollarSign,
   Scale,
+  ShieldAlert,
+  Sparkles,
+  ChevronRight,
+  AlertTriangle,
 } from 'lucide-react';
 import { Button, Dialog, Select, type SelectOption } from '@crypto-trader/ui';
 import { useTranslation } from 'react-i18next';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   useAgentConfigs,
   useAgentHealth,
   useUpdateAgentConfig,
   useResetAgentConfig,
   useApplyPreset,
+  useAutoResolveFallback,
   ResolvedAgentConfig,
   AgentPresetName,
 } from '../../../hooks/use-agent-config';
-import { useLLMKeys } from '../../../hooks/use-user';
+import {
+  useLLMKeys,
+  useUpdateLLMModel,
+  usePlatformLLMStatus,
+} from '../../../hooks/use-user';
 import { DynamicModelSelect } from '../../../containers/settings/dynamic-model-select';
+import { OpenRouterModelSelect } from '../../../containers/settings/openrouter-model-select';
 import { cn } from '../../../lib/utils';
 
 const AGENT_META: Record<
@@ -86,7 +96,7 @@ function AgentConfigCard({
   const isOverridden = config.source === 'user';
 
   return (
-    <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+    <div className="rounded-xl border border-border bg-card p-4 space-y-3 h-full">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           {meta.locked && <Lock className="h-4 w-4 text-red-500" />}
@@ -111,7 +121,7 @@ function AgentConfigCard({
         </span>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div className="space-y-3">
         <div>
           <Select
             label={t('settings.agents.provider')}
@@ -177,11 +187,41 @@ export function SettingsAgentsPage() {
   const updateMutation = useUpdateAgentConfig();
   const resetMutation = useResetAgentConfig();
   const applyPreset = useApplyPreset();
+  const autoResolve = useAutoResolveFallback();
+  const updateLLMModel = useUpdateLLMModel();
+  const { data: platformStatus } = usePlatformLLMStatus();
+
+  // Build a set of inactive providers for quick lookup
+  const inactiveProviders = useMemo(
+    () =>
+      new Set(
+        (platformStatus ?? [])
+          .filter((p) => !p.isActive)
+          .map((p) => p.provider),
+      ),
+    [platformStatus],
+  );
 
   const [pendingPreset, setPendingPreset] = useState<{
     id: AgentPresetName;
     name: string;
   } | null>(null);
+
+  // Fallback model state
+  const openRouterCred = (llmKeys ?? []).find(
+    (k) => k.provider === 'OPENROUTER' && k.isActive,
+  );
+  const [fallbackModel, setFallbackModel] = useState(
+    openRouterCred?.selectedModel ?? '',
+  );
+  const [fallbackDirty, setFallbackDirty] = useState(false);
+
+  useEffect(() => {
+    if (openRouterCred?.selectedModel) {
+      setFallbackModel(openRouterCred.selectedModel);
+      setFallbackDirty(false);
+    }
+  }, [openRouterCred?.selectedModel]);
 
   const activeProviders = (llmKeys ?? [])
     .filter((k) => k.isActive)
@@ -260,6 +300,28 @@ export function SettingsAgentsPage() {
   );
   const aegisConfig = (configs ?? []).find((c) => c.agentId === 'risk');
 
+  // All agents in display order for the vertical nav
+  const allAgentConfigs = useMemo(() => {
+    const list: ResolvedAgentConfig[] = [];
+    list.push(...kryptoConfigs);
+    list.push(...standardConfigs);
+    if (aegisConfig) list.push(aegisConfig);
+    return list;
+  }, [kryptoConfigs, standardConfigs, aegisConfig]);
+
+  const [selectedAgentId, setSelectedAgentId] = useState<string>('');
+
+  // Set initial selected agent once loaded
+  useEffect(() => {
+    if (allAgentConfigs.length > 0 && !selectedAgentId) {
+      setSelectedAgentId(allAgentConfigs[0].agentId);
+    }
+  }, [allAgentConfigs, selectedAgentId]);
+
+  const selectedConfig = allAgentConfigs.find(
+    (c) => c.agentId === selectedAgentId,
+  );
+
   return (
     <div className="p-6 space-y-6">
       {/* Header */}
@@ -316,6 +378,84 @@ export function SettingsAgentsPage() {
         </div>
       </div>
 
+      {/* ── Fallback Model ──────────────────────────────────────────── */}
+      {openRouterCred && (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <ShieldAlert className="h-4 w-4 text-amber-500" />
+              <h2 className="text-sm font-semibold">
+                {t('settings.agents.fallback.title', {
+                  defaultValue: 'Fallback Model',
+                })}
+              </h2>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={autoResolve.isPending}
+              onClick={() => autoResolve.mutate()}
+            >
+              {autoResolve.isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin mr-1" />
+              ) : (
+                <Sparkles className="h-3 w-3 mr-1" />
+              )}
+              {t('settings.agents.fallback.autoResolve', {
+                defaultValue: 'Auto-resolve',
+              })}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {t('settings.agents.fallback.description', {
+              defaultValue:
+                'Safety net model used when an agent has no specific configuration. Applied automatically by presets.',
+            })}
+          </p>
+          <OpenRouterModelSelect
+            value={fallbackModel}
+            onChange={(m) => {
+              setFallbackModel(m);
+              setFallbackDirty(true);
+            }}
+            compact
+          />
+          {fallbackDirty && (
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                disabled={updateLLMModel.isPending || !fallbackModel}
+                onClick={() =>
+                  updateLLMModel.mutate(
+                    {
+                      provider: 'OPENROUTER',
+                      selectedModel: fallbackModel,
+                    },
+                    { onSuccess: () => setFallbackDirty(false) },
+                  )
+                }
+              >
+                {updateLLMModel.isPending && (
+                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                )}
+                <Save className="h-3 w-3 mr-1" />
+                {t('common.save')}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setFallbackModel(openRouterCred?.selectedModel ?? '');
+                  setFallbackDirty(false);
+                }}
+              >
+                {t('common.cancel', { defaultValue: 'Cancel' })}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Health warning */}
       {health && !health.healthy && (
         <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm text-yellow-600 dark:text-yellow-400">
@@ -323,64 +463,97 @@ export function SettingsAgentsPage() {
         </div>
       )}
 
-      {/* KRYPTO — dual model (routing + synthesis) */}
-      {kryptoConfigs.length > 0 && (
-        <div className="space-y-3">
-          <h2 className="text-lg font-semibold text-yellow-500">
-            KRYPTO — {t('settings.agents.orchestrator')}
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {kryptoConfigs.map((cfg) => (
+      {/* ── Agent Configuration — Vertical Tabs ─────────────────── */}
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">
+          {t('settings.agents.specialists')}
+        </h2>
+
+        {/* Mobile: dropdown selector */}
+        <div className="block md:hidden">
+          <Select
+            value={selectedAgentId}
+            onChange={setSelectedAgentId}
+            options={allAgentConfigs.map((cfg) => {
+              const m = AGENT_META[cfg.agentId] ?? {
+                codename: cfg.agentId,
+                color: '',
+              };
+              const needsAttention =
+                cfg.provider && inactiveProviders.has(cfg.provider);
+              return {
+                value: cfg.agentId,
+                label: needsAttention
+                  ? `⚠️ ${m.codename} (${cfg.agentId})`
+                  : `${m.codename} (${cfg.agentId})`,
+              };
+            })}
+          />
+        </div>
+
+        <div className="flex gap-4 items-stretch">
+          {/* Desktop: vertical nav */}
+          <div className="hidden md:flex flex-col gap-1 w-48 shrink-0 rounded-xl border border-border bg-card p-2">
+            {allAgentConfigs.map((cfg) => {
+              const m = AGENT_META[cfg.agentId] ?? {
+                codename: cfg.agentId,
+                color: 'text-muted-foreground',
+              };
+              const isActive = cfg.agentId === selectedAgentId;
+              const needsAttention =
+                cfg.provider && inactiveProviders.has(cfg.provider);
+              return (
+                <button
+                  key={cfg.agentId}
+                  type="button"
+                  onClick={() => setSelectedAgentId(cfg.agentId)}
+                  className={cn(
+                    'flex items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-all duration-150',
+                    isActive
+                      ? 'bg-primary/10 text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                  )}
+                >
+                  {needsAttention ? (
+                    <AlertTriangle className="h-3.5 w-3.5 text-amber-500 shrink-0" />
+                  ) : (
+                    m.locked && (
+                      <Lock className="h-3.5 w-3.5 text-red-500 shrink-0" />
+                    )
+                  )}
+                  <span className={cn('font-bold', m.color)}>{m.codename}</span>
+                  <span className="text-[10px] text-muted-foreground truncate">
+                    {cfg.agentId}
+                  </span>
+                  {needsAttention && (
+                    <span className="ml-auto text-[9px] text-amber-500 font-semibold shrink-0">
+                      {t('agents.providerNeedsAttention')}
+                    </span>
+                  )}
+                  {isActive && !needsAttention && (
+                    <ChevronRight className="ml-auto h-3.5 w-3.5 text-primary shrink-0" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Card content */}
+          <div className="flex-1 min-w-0">
+            {selectedConfig && (
               <AgentConfigCard
-                key={cfg.agentId}
-                config={cfg}
+                key={selectedConfig.agentId}
+                config={selectedConfig}
                 activeProviders={activeProviders}
                 onSave={handleSave}
                 onReset={handleReset}
                 isSaving={updateMutation.isPending}
                 t={t}
               />
-            ))}
+            )}
           </div>
         </div>
-      )}
-
-      {/* Standard agents: NEXUS, FORGE, SIGMA, CIPHER */}
-      <div className="space-y-3">
-        <h2 className="text-lg font-semibold">
-          {t('settings.agents.specialists')}
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {standardConfigs.map((cfg) => (
-            <AgentConfigCard
-              key={cfg.agentId}
-              config={cfg}
-              activeProviders={activeProviders}
-              onSave={handleSave}
-              onReset={handleReset}
-              isSaving={updateMutation.isPending}
-              t={t}
-            />
-          ))}
-        </div>
       </div>
-
-      {/* AEGIS — locked */}
-      {aegisConfig && (
-        <div className="space-y-3">
-          <h2 className="text-lg font-semibold text-red-500">
-            AEGIS — {t('settings.agents.riskManager')}
-          </h2>
-          <AgentConfigCard
-            config={aegisConfig}
-            activeProviders={activeProviders}
-            onSave={handleSave}
-            onReset={handleReset}
-            isSaving={updateMutation.isPending}
-            t={t}
-          />
-        </div>
-      )}
 
       {/* Preset confirmation dialog */}
       <Dialog

--- a/apps/web/src/pages/dashboard/settings/llms.tsx
+++ b/apps/web/src/pages/dashboard/settings/llms.tsx
@@ -9,6 +9,7 @@ import {
   BarChart3,
   Star,
   AlertTriangle,
+  Ban,
 } from 'lucide-react';
 import { Button, Input } from '@crypto-trader/ui';
 import { cn } from '../../../lib/utils';
@@ -20,6 +21,7 @@ import {
   useUpdateLLMModel,
   useTestLLMKey,
   useValidateAllLLMKeys,
+  usePlatformLLMStatus,
 } from '../../../hooks/use-user';
 import { DynamicModelSelect } from '../../../containers/settings/dynamic-model-select';
 import { AIUsageDashboard } from '../../../containers/settings/ai-usage-dashboard';
@@ -85,16 +87,7 @@ const LLM_PROVIDERS = [
   {
     value: 'OPENROUTER',
     label: 'OpenRouter',
-    models: [
-      'anthropic/claude-sonnet-4.6',
-      'google/gemini-3-flash-preview',
-      'anthropic/claude-opus-4.6',
-      'deepseek/deepseek-v3.2',
-      'google/gemini-2.5-flash-lite',
-      'openrouter/elephant-alpha',
-      'nvidia/nemotron-3-super-120b-a12b:free',
-      'google/gemma-4-31b-it:free',
-    ],
+    models: [], // Resolved dynamically via useOpenRouterModels hook
     helpLink: 'https://openrouter.ai/keys',
     helpLinkText: 'openrouter.ai',
   },
@@ -108,6 +101,7 @@ export function SettingsLLMsPage() {
 
   // LLM Keys
   const { data: llmKeys = [] } = useLLMKeys();
+  const { data: platformStatus = [] } = usePlatformLLMStatus();
   const hasActiveKey = llmKeys.some((k) => k.isActive);
   const { mutate: saveLLMKey, isPending: savingLLM } = useSetLLMKey();
   const { mutate: deleteLLMKey } = useDeleteLLMKey();
@@ -245,7 +239,6 @@ export function SettingsLLMsPage() {
           }
           onTest={(provider) => testLLM(provider)}
           onDelete={(provider) => deleteLLMKey(provider)}
-          onUpdateModel={(data) => updateLLMModel(data)}
         />
       )}
 
@@ -315,25 +308,44 @@ export function SettingsLLMsPage() {
                   const validation = llmValidation?.results.find(
                     (r) => r.provider === provider.value,
                   );
+                  const platformProvider = platformStatus.find(
+                    (p) => p.provider === provider.value,
+                  );
+                  const isDisabledByAdmin =
+                    platformProvider?.isActive === false;
                   const manualTestFailed =
                     status?.isActive &&
                     llmTestResult &&
                     llmTestProvider === provider.value &&
                     !llmTestResult.connected;
-                  const resolvedStatus = manualTestFailed
-                    ? 'INVALID'
-                    : (validation?.status ??
-                      (status?.isActive ? 'ACTIVE' : 'INACTIVE'));
+                  const resolvedStatus = isDisabledByAdmin
+                    ? 'DISABLED'
+                    : manualTestFailed
+                      ? 'INVALID'
+                      : (validation?.status ??
+                        (status?.isActive ? 'ACTIVE' : 'INACTIVE'));
                   return (
                     <div
                       key={provider.value}
-                      className="rounded-lg border border-border p-4"
+                      className={cn(
+                        'rounded-lg border p-4',
+                        isDisabledByAdmin
+                          ? 'border-red-500/20 bg-red-500/5 opacity-70'
+                          : 'border-border',
+                      )}
                     >
                       <div className="mb-3 flex items-center justify-between">
                         <span className="font-medium text-sm">
                           {provider.label}
                         </span>
-                        {validatingLLMKeys && status?.isActive ? (
+                        {isDisabledByAdmin ? (
+                          <span className="flex items-center gap-1.5 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-semibold text-red-400">
+                            <Ban className="h-3 w-3" />
+                            {t('settings.disabledByAdmin', {
+                              defaultValue: 'Disabled',
+                            })}
+                          </span>
+                        ) : validatingLLMKeys && status?.isActive ? (
                           <span className="flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-semibold text-amber-500">
                             <Loader2 className="h-3 w-3 animate-spin" />
                             {t('settings.validating')}
@@ -357,159 +369,173 @@ export function SettingsLLMsPage() {
                           </span>
                         )}
                       </div>
-                      <div className="grid gap-3 sm:grid-cols-1">
-                        <div>
-                          <label className="mb-1 block text-xs font-medium">
-                            API Key
-                          </label>
-                          <Input
-                            type="password"
-                            placeholder="sk-..."
-                            value={form.apiKey}
-                            onChange={(e) =>
-                              setLlmForms((f) => ({
-                                ...f,
-                                [provider.value]: {
-                                  ...(f[provider.value] ?? {
-                                    model: provider.models[0],
-                                  }),
-                                  apiKey: e.target.value,
-                                },
-                              }))
-                            }
-                            className="px-2 py-2"
-                          />
-                          <p className="mt-1.5 text-xs text-muted-foreground">
-                            {t('settings.getApiKeyAt')}{' '}
-                            <a
-                              href={provider.helpLink}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-flex items-center gap-1 text-primary hover:underline font-medium"
-                            >
-                              {provider.helpLinkText}
-                              <ExternalLink className="h-3 w-3" />
-                            </a>
-                          </p>
+
+                      {isDisabledByAdmin ? (
+                        <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-xs text-red-400 leading-relaxed">
+                          <Ban className="inline h-3 w-3 mr-1 -mt-0.5" />
+                          {t('settings.providerDisabledNotice', {
+                            defaultValue:
+                              'This provider has been temporarily disabled by the administrator. For more details, please contact us.',
+                          })}
                         </div>
-                        {status?.isActive ? (
-                          <div>
-                            <DynamicModelSelect
-                              provider={provider.value}
-                              value={form.model}
-                              label={t('settings.model')}
-                              onChange={(model) => {
-                                setLlmForms((f) => ({
-                                  ...f,
-                                  [provider.value]: {
-                                    ...(f[provider.value] ?? {
-                                      apiKey: '',
-                                    }),
-                                    model,
-                                  },
-                                }));
-                                updateLLMModel({
-                                  provider: provider.value,
-                                  selectedModel: model || null,
-                                });
-                              }}
-                              fallbackModels={provider.models}
-                            />
-                          </div>
-                        ) : (
-                          <div className="mt-2 rounded-lg border border-dashed border-border bg-muted/20 p-3 text-xs text-muted-foreground italic text-center">
-                            {t('settings.activateProviderFirst', {
-                              defaultValue:
-                                'Guarda tu API key para seleccionar un modelo',
-                            })}
-                          </div>
-                        )}
-                      </div>
-                      <div className="mt-3 flex flex-wrap items-center gap-2">
-                        <Button
-                          size="sm"
-                          disabled={savingLLM || !form.apiKey}
-                          onClick={() =>
-                            saveLLMKey(
-                              {
-                                provider: provider.value,
-                                apiKey: form.apiKey,
-                                selectedModel: form.model || null,
-                              },
-                              {
-                                onSuccess: () => {
+                      ) : (
+                        <>
+                          <div className="grid gap-3 sm:grid-cols-1">
+                            <div>
+                              <label className="mb-1 block text-xs font-medium">
+                                API Key
+                              </label>
+                              <Input
+                                type="password"
+                                placeholder="sk-..."
+                                value={form.apiKey}
+                                onChange={(e) =>
                                   setLlmForms((f) => ({
                                     ...f,
                                     [provider.value]: {
-                                      apiKey: '',
-                                      model: '',
+                                      ...(f[provider.value] ?? {
+                                        model: provider.models[0],
+                                      }),
+                                      apiKey: e.target.value,
                                     },
-                                  }));
-                                  resetLLMTest();
-                                },
-                              },
-                            )
-                          }
-                        >
-                          {savingLLM && (
-                            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                          )}
-                          {t('common.save')}
-                        </Button>
-                        {status?.isActive && (
-                          <>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              disabled={testingLLM}
-                              onClick={() => testLLM(provider.value)}
-                            >
-                              {testingLLM &&
-                                llmTestProvider === provider.value && (
-                                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                                )}
-                              {testingLLM && llmTestProvider === provider.value
-                                ? t('settings.testing')
-                                : t('settings.testConnection')}
-                            </Button>
-                            {llmTestResult &&
-                              llmTestProvider === provider.value && (
-                                <span
-                                  className={cn(
-                                    'text-xs font-medium',
-                                    llmTestResult.connected
-                                      ? 'text-emerald-500'
-                                      : 'text-red-500',
-                                  )}
+                                  }))
+                                }
+                                className="px-2 py-2"
+                              />
+                              <p className="mt-1.5 text-xs text-muted-foreground">
+                                {t('settings.getApiKeyAt')}{' '}
+                                <a
+                                  href={provider.helpLink}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="inline-flex items-center gap-1 text-primary hover:underline font-medium"
                                 >
-                                  {llmTestResult.connected
-                                    ? t('settings.testSuccess')
-                                    : `${t('settings.testFailed')}: ${llmTestResult.error}`}
-                                </span>
-                              )}
-                            {validation?.status === 'INVALID' &&
-                              validation.error &&
-                              !(
-                                llmTestResult &&
-                                llmTestProvider === provider.value
-                              ) && (
-                                <span className="text-xs font-medium text-red-500">
-                                  {t('settings.autoValidationFailed')}:{' '}
-                                  {validation.error}
-                                </span>
-                              )}
+                                  {provider.helpLinkText}
+                                  <ExternalLink className="h-3 w-3" />
+                                </a>
+                              </p>
+                            </div>
+                            {status?.isActive ? (
+                              <div>
+                                <DynamicModelSelect
+                                  provider={provider.value}
+                                  value={form.model}
+                                  label={t('settings.model')}
+                                  onChange={(model) => {
+                                    setLlmForms((f) => ({
+                                      ...f,
+                                      [provider.value]: {
+                                        ...(f[provider.value] ?? {
+                                          apiKey: '',
+                                        }),
+                                        model,
+                                      },
+                                    }));
+                                    updateLLMModel({
+                                      provider: provider.value,
+                                      selectedModel: model || null,
+                                    });
+                                  }}
+                                  fallbackModels={provider.models}
+                                />
+                              </div>
+                            ) : (
+                              <div className="mt-2 rounded-lg border border-dashed border-border bg-muted/20 p-3 text-xs text-muted-foreground italic text-center">
+                                {t('settings.activateProviderFirst', {
+                                  defaultValue:
+                                    'Guarda tu API key para seleccionar un modelo',
+                                })}
+                              </div>
+                            )}
+                          </div>
+                          <div className="mt-3 flex flex-wrap items-center gap-2">
                             <Button
                               size="sm"
-                              variant="ghost"
-                              className="gap-1.5 text-red-500 hover:text-red-600"
-                              onClick={() => deleteLLMKey(provider.value)}
+                              disabled={savingLLM || !form.apiKey}
+                              onClick={() =>
+                                saveLLMKey(
+                                  {
+                                    provider: provider.value,
+                                    apiKey: form.apiKey,
+                                    selectedModel: form.model || null,
+                                  },
+                                  {
+                                    onSuccess: () => {
+                                      setLlmForms((f) => ({
+                                        ...f,
+                                        [provider.value]: {
+                                          apiKey: '',
+                                          model: '',
+                                        },
+                                      }));
+                                      resetLLMTest();
+                                    },
+                                  },
+                                )
+                              }
                             >
-                              <Trash2 className="h-3 w-3" />
-                              {t('settings.remove')}
+                              {savingLLM && (
+                                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                              )}
+                              {t('common.save')}
                             </Button>
-                          </>
-                        )}
-                      </div>
+                            {status?.isActive && (
+                              <>
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  disabled={testingLLM}
+                                  onClick={() => testLLM(provider.value)}
+                                >
+                                  {testingLLM &&
+                                    llmTestProvider === provider.value && (
+                                      <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                                    )}
+                                  {testingLLM &&
+                                  llmTestProvider === provider.value
+                                    ? t('settings.testing')
+                                    : t('settings.testConnection')}
+                                </Button>
+                                {llmTestResult &&
+                                  llmTestProvider === provider.value && (
+                                    <span
+                                      className={cn(
+                                        'text-xs font-medium',
+                                        llmTestResult.connected
+                                          ? 'text-emerald-500'
+                                          : 'text-red-500',
+                                      )}
+                                    >
+                                      {llmTestResult.connected
+                                        ? t('settings.testSuccess')
+                                        : `${t('settings.testFailed')}: ${llmTestResult.error}`}
+                                    </span>
+                                  )}
+                                {validation?.status === 'INVALID' &&
+                                  validation.error &&
+                                  !(
+                                    llmTestResult &&
+                                    llmTestProvider === provider.value
+                                  ) && (
+                                    <span className="text-xs font-medium text-red-500">
+                                      {t('settings.autoValidationFailed')}:{' '}
+                                      {validation.error}
+                                    </span>
+                                  )}
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  className="gap-1.5 text-red-500 hover:text-red-600"
+                                  onClick={() => deleteLLMKey(provider.value)}
+                                >
+                                  <Trash2 className="h-3 w-3" />
+                                  {t('settings.remove')}
+                                </Button>
+                              </>
+                            )}
+                          </div>
+                        </>
+                      )}
                     </div>
                   );
                 },

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -13,11 +13,12 @@
 **Principios fundacionales:**
 
 1. **Autonomía** — el agente opera sin intervención manual una vez configurado.
-2. **Inteligencia híbrida** — análisis técnico clásico + LLM multi-proveedor (Claude, OpenAI, Groq).
+2. **Inteligencia híbrida** — análisis técnico clásico + LLM multi-proveedor (OpenRouter, Claude, OpenAI, Groq, Gemini, Mistral, Together).
 3. **Multi-usuario aislado** — cada usuario gestiona sus propias claves, configuraciones y fondos independientes.
 4. **Seguro por defecto** — modo Sandbox obligatorio hasta que el usuario elija explícitamente modo Live.
-5. **Transparencia total** — cada decisión del agente queda registrada con razonamiento, indicadores y contexto de noticias.
+5. **Transparencia total** — cada decisión del agente queda registrada con razonamiento, indicadores, proveedor/modelo y contexto de noticias.
 6. **Adaptable** — el agente aprende intervalos óptimos de análisis basados en experiencia acumulada.
+7. **Gobernanza admin** — el administrador controla qué proveedores LLM están activos globalmente; los usuarios reciben notificación al desactivar uno.
 
 ---
 
@@ -32,6 +33,7 @@ crypto-trader/                    ← raíz del workspace NX
 │   ├── analysis/                 ← Indicadores técnicos + integración LLM
 │   ├── data-fetcher/             ← Binance OHLCV, noticias, RSS
 │   ├── trading-engine/           ← Lógica de órdenes y posiciones
+│   ├── openrouter/               ← Catálogo dinámico de modelos OpenRouter (SDK + cache)
 │   ├── shared/                   ← Types, DTOs, constantes, utils
 │   └── ui/                       ← Design system React (52 componentes stateless)
 ├── docs/
@@ -48,10 +50,11 @@ crypto-trader/                    ← raíz del workspace NX
 ### Reglas de dependencias entre libs
 
 ```
-web  →  shared, ui, analysis (tipos)
-api  →  shared, analysis, data-fetcher, trading-engine
+web  →  shared, ui, analysis (tipos), openrouter (tipos)
+api  →  shared, analysis, data-fetcher, trading-engine, openrouter
 analysis   →  shared, data-fetcher
 trading-engine  →  shared, analysis, data-fetcher
+openrouter →  (ninguna dep interna)
 data-fetcher  →  shared
 ui  →  shared
 ```
@@ -114,7 +117,7 @@ ui  →  shared
 
 | Proveedor              | SDK                     | Modelos soportados                  |
 | ---------------------- | ----------------------- | ----------------------------------- |
-| **OpenRouter** ⭐      | HTTP (OpenAI-compat)    | 200+ modelos de todos los providers |
+| **OpenRouter** ⭐      | `@openrouter/sdk`       | 200+ modelos de todos los providers (catálogo dinámico con cache 15min) |
 | **Anthropic (Claude)** | `@anthropic-ai/sdk`     | claude-sonnet-4-6, claude-haiku-4-5 |
 | **OpenAI**             | `openai`                | gpt-4o, gpt-4o-mini                 |
 | **Groq**               | `groq-sdk`              | llama-3.3-70b, mixtral-8x7b         |
@@ -168,7 +171,10 @@ api/src/
 ├── users/              UsersModule      — CRUD, Binance keys (AES-256), LLM keys
 ├── trading/            TradingModule    — Ciclo de vida agente, órdenes, posiciones
 ├── analysis/           AnalysisModule   — LLM, indicadores, noticias
-├── market/             MarketModule     — OHLCV, Market snapshot, noticias caché
+├── llm/                LlmModule        — Modelos, pricing, ranking, provider toggle admin
+├── orchestrator/       OrchestratorModule — Agente multi-sub (orchestrator, market, risk, tech, fundamentals)
+├── openrouter/         OpenRouterModule — Catálogo dinámico de modelos vía @openrouter/sdk
+├── market/             MarketModule     — OHLCV, Market snapshot, noticias caché, sentimiento AI
 ├── notifications/      NotificationsModule — Centro de notificaciones + WebSocket
 ├── analytics/          AnalyticsModule  — P&L, win rate, decisiones
 ├── admin/              AdminModule      — Kill-switch global, gestión de usuarios
@@ -184,10 +190,11 @@ api/src/
 3. analysis: Calcular indicadores (RSI, MACD, BB, EMA, Volumen, S&R)
 4. data-fetcher: Noticias recientes (CryptoPanic / RSS)
 5. AgentConfigResolver: resolver proveedor/modelo por agente (usuario > admin > fallback)
-6. LLM call → { decision, confidence, reasoning, waitMinutes }
-6. trading-engine: Si confidence ≥ threshold → ejecutar orden en Binance
-7. DB: Guardar AgentDecision + Trade + actualizar Position
-8. WebSocket: Emitir eventos al frontend (trade:executed, agent:decision)
+6. PlatformLLMProviderService: verificar que el provider está activo globalmente
+7. LLM call → { decision, confidence, reasoning, waitMinutes, llmProvider, llmModel }
+7. trading-engine: Si confidence ≥ threshold → ejecutar orden en Binance
+8. DB: Guardar AgentDecision + Trade + actualizar Position + persistir sentimiento en NewsAnalysis
+9. WebSocket: Emitir eventos al frontend (trade:executed, agent:decision)
 9. Bull: Reprogramar siguiente job según waitMinutes
 ```
 
@@ -269,7 +276,7 @@ Todos los componentes de UI stateless viven en `libs/ui`. Las apps consumen vía
 | **Theme**         | ThemeProvider                                                                                                                                   |
 | **Charts**        | ChartCard, ChartTooltip, ChartTheme (constantes)                                                                                                |
 | **Domain/Market** | StatCard, PriceTicker, IndicatorInfoModal                                                                                                       |
-| **Domain/Agent**  | DecisionFlowDiagram, ExplainPanel, ParameterCards, StrategyPresets, AgentConfigCard, ProviderSearchSelect, ModelSearchSelect                    |
+| **Domain/Agent**  | DecisionFlowDiagram, ExplainPanel, ParameterCards, StrategyPresets, AgentConfigCard, ProviderSearchSelect, ModelSearchSelect, ModelInfoModal |
 | **Domain/Chat**   | AgentHeader, AgentSelector, CapabilityButtons, ChatInput, OrchestratingIndicator, ToolCallCard, QuickActionButtons, ChatInlineOptions           |
 | **Domain/Help**   | HelpSidebar                                                                                                                                     |
 
@@ -331,6 +338,7 @@ Todos los componentes de UI stateless viven en `libs/ui`. Las apps consumen vía
 | `ChatSession` / `ChatMessage` | Historial del chat con el asistente IA (provider/model opcionales, resueltos por agente)                    |
 | `AgentConfig`                 | Override de proveedor/modelo por agente por usuario                                                         |
 | `AdminAgentConfig`            | Defaults globales de proveedor/modelo por agente (solo OpenRouter, seteados por Admin)                      |
+| `PlatformLLMProvider`         | Estado global de cada proveedor LLM (activo/inactivo), controlado por Admin                                 |
 | `SandboxWallet`               | Wallet virtual para modo Sandbox                                                                            |
 | `NewsConfig`                  | Config de noticias por usuario (botEnabled, newsWeight)                                                     |
 | `NewsAnalysis`                | Análisis de noticias generado por LLM                                                                       |
@@ -494,6 +502,8 @@ pnpm nx affected --target=test   # Solo testear lo afectado por cambios
 | 13  | OpenRouter como provider recomendado      | Una API key → 200+ modelos, fallback automático, billing unificado; reduce fricción de onboarding                                              |
 | 14  | Agent Hub: config centralizada por agente | Un agente = un par proveedor/modelo. Resolución: usuario > admin > hardcoded fallback. Elimina config LLM dispersa en TradingConfig/NewsConfig |
 | 15  | Chat resuelve LLM por agente (no manual)  | El chat usa `AgentConfigResolver` según el agente activo. Sin selección manual de provider/model. "Primary Model" en settings es solo fallback |
+| 16  | Toggle admin de proveedores LLM           | El admin puede activar/desactivar proveedores globalmente. Al desactivar: limpia AgentConfigs afectados, notifica usuarios, registra AdminAction. Endpoints validan vía `assertProviderActive()` (409) |
+| 17  | Catálogo OpenRouter dinámico              | Los modelos OpenRouter no están hardcoded — se obtienen de la API con cache 15min (`libs/openrouter`). Pricing, ranking y presets se construyen dinámicamente |
 
 ---
 

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -115,15 +115,15 @@ ui  →  shared
 
 ### 3.4 Proveedores LLM (multi-proveedor, por usuario)
 
-| Proveedor              | SDK                     | Modelos soportados                  |
-| ---------------------- | ----------------------- | ----------------------------------- |
+| Proveedor              | SDK                     | Modelos soportados                                                      |
+| ---------------------- | ----------------------- | ----------------------------------------------------------------------- |
 | **OpenRouter** ⭐      | `@openrouter/sdk`       | 200+ modelos de todos los providers (catálogo dinámico con cache 15min) |
-| **Anthropic (Claude)** | `@anthropic-ai/sdk`     | claude-sonnet-4-6, claude-haiku-4-5 |
-| **OpenAI**             | `openai`                | gpt-4o, gpt-4o-mini                 |
-| **Groq**               | `groq-sdk`              | llama-3.3-70b, mixtral-8x7b         |
-| **Google (Gemini)**    | `@google/generative-ai` | gemini-2.5-flash, gemini-2.5-pro    |
-| **Mistral**            | `@mistralai/mistralai`  | mistral-large, mistral-small        |
-| **Together**           | HTTP (OpenAI-compat)    | llama, mixtral, qwen                |
+| **Anthropic (Claude)** | `@anthropic-ai/sdk`     | claude-sonnet-4-6, claude-haiku-4-5                                     |
+| **OpenAI**             | `openai`                | gpt-4o, gpt-4o-mini                                                     |
+| **Groq**               | `groq-sdk`              | llama-3.3-70b, mixtral-8x7b                                             |
+| **Google (Gemini)**    | `@google/generative-ai` | gemini-2.5-flash, gemini-2.5-pro                                        |
+| **Mistral**            | `@mistralai/mistralai`  | mistral-large, mistral-small                                            |
+| **Together**           | HTTP (OpenAI-compat)    | llama, mixtral, qwen                                                    |
 
 > **OpenRouter** es el proveedor **primario recomendado**: una sola API key da acceso a todos los modelos con fallback automático y billing unificado. Los proveedores directos siguen soportados como alternativa.
 
@@ -276,7 +276,7 @@ Todos los componentes de UI stateless viven en `libs/ui`. Las apps consumen vía
 | **Theme**         | ThemeProvider                                                                                                                                   |
 | **Charts**        | ChartCard, ChartTooltip, ChartTheme (constantes)                                                                                                |
 | **Domain/Market** | StatCard, PriceTicker, IndicatorInfoModal                                                                                                       |
-| **Domain/Agent**  | DecisionFlowDiagram, ExplainPanel, ParameterCards, StrategyPresets, AgentConfigCard, ProviderSearchSelect, ModelSearchSelect, ModelInfoModal |
+| **Domain/Agent**  | DecisionFlowDiagram, ExplainPanel, ParameterCards, StrategyPresets, AgentConfigCard, ProviderSearchSelect, ModelSearchSelect, ModelInfoModal    |
 | **Domain/Chat**   | AgentHeader, AgentSelector, CapabilityButtons, ChatInput, OrchestratingIndicator, ToolCallCard, QuickActionButtons, ChatInlineOptions           |
 | **Domain/Help**   | HelpSidebar                                                                                                                                     |
 
@@ -485,25 +485,25 @@ pnpm nx affected --target=test   # Solo testear lo afectado por cambios
 
 ## 11. Decisiones Arquitecturales Clave
 
-| #   | Decisión                                  | Razón                                                                                                                                          |
-| --- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Monorepo NX                               | Compartir tipos y lógica entre web/api sin duplicación                                                                                         |
-| 2   | pnpm workspaces                           | Performance y correctness en resolución de dependencias                                                                                        |
-| 3   | NestJS para API                           | DI robusto, módulos, decoradores — ideal para arquitectura multi-dominio                                                                       |
-| 4   | Prisma ORM                                | Type-safety end-to-end, migraciones declarativas                                                                                               |
-| 5   | Bull + Redis para colas                   | Garantía de entrega de trabajos de análisis; reintentos automáticos                                                                            |
-| 6   | AES-256-GCM para claves                   | Estándar de la industria; clave maestra separada de los datos                                                                                  |
-| 7   | LLM por usuario (no global)               | Costos atribuibles al usuario; flexibilidad de proveedor                                                                                       |
-| 8   | GitHub Pages para web                     | Cero costo; build estático compatible con React Router                                                                                         |
-| 9   | Railway para API                          | Deploy desde Dockerfile; PostgreSQL + Redis incluidos                                                                                          |
-| 10  | Sandbox server-side enforced              | Nunca confiar en el cliente para prevenir órdenes reales                                                                                       |
-| 11  | TanStack Query para server state          | Caché, refetch, stale-time — evita useEffect para fetching                                                                                     |
-| 12  | i18n desde el inicio                      | Evitar deuda de localización; arquitectura bilingüe nativa                                                                                     |
-| 13  | OpenRouter como provider recomendado      | Una API key → 200+ modelos, fallback automático, billing unificado; reduce fricción de onboarding                                              |
-| 14  | Agent Hub: config centralizada por agente | Un agente = un par proveedor/modelo. Resolución: usuario > admin > hardcoded fallback. Elimina config LLM dispersa en TradingConfig/NewsConfig |
-| 15  | Chat resuelve LLM por agente (no manual)  | El chat usa `AgentConfigResolver` según el agente activo. Sin selección manual de provider/model. "Primary Model" en settings es solo fallback |
+| #   | Decisión                                  | Razón                                                                                                                                                                                                  |
+| --- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Monorepo NX                               | Compartir tipos y lógica entre web/api sin duplicación                                                                                                                                                 |
+| 2   | pnpm workspaces                           | Performance y correctness en resolución de dependencias                                                                                                                                                |
+| 3   | NestJS para API                           | DI robusto, módulos, decoradores — ideal para arquitectura multi-dominio                                                                                                                               |
+| 4   | Prisma ORM                                | Type-safety end-to-end, migraciones declarativas                                                                                                                                                       |
+| 5   | Bull + Redis para colas                   | Garantía de entrega de trabajos de análisis; reintentos automáticos                                                                                                                                    |
+| 6   | AES-256-GCM para claves                   | Estándar de la industria; clave maestra separada de los datos                                                                                                                                          |
+| 7   | LLM por usuario (no global)               | Costos atribuibles al usuario; flexibilidad de proveedor                                                                                                                                               |
+| 8   | GitHub Pages para web                     | Cero costo; build estático compatible con React Router                                                                                                                                                 |
+| 9   | Railway para API                          | Deploy desde Dockerfile; PostgreSQL + Redis incluidos                                                                                                                                                  |
+| 10  | Sandbox server-side enforced              | Nunca confiar en el cliente para prevenir órdenes reales                                                                                                                                               |
+| 11  | TanStack Query para server state          | Caché, refetch, stale-time — evita useEffect para fetching                                                                                                                                             |
+| 12  | i18n desde el inicio                      | Evitar deuda de localización; arquitectura bilingüe nativa                                                                                                                                             |
+| 13  | OpenRouter como provider recomendado      | Una API key → 200+ modelos, fallback automático, billing unificado; reduce fricción de onboarding                                                                                                      |
+| 14  | Agent Hub: config centralizada por agente | Un agente = un par proveedor/modelo. Resolución: usuario > admin > hardcoded fallback. Elimina config LLM dispersa en TradingConfig/NewsConfig                                                         |
+| 15  | Chat resuelve LLM por agente (no manual)  | El chat usa `AgentConfigResolver` según el agente activo. Sin selección manual de provider/model. "Primary Model" en settings es solo fallback                                                         |
 | 16  | Toggle admin de proveedores LLM           | El admin puede activar/desactivar proveedores globalmente. Al desactivar: limpia AgentConfigs afectados, notifica usuarios, registra AdminAction. Endpoints validan vía `assertProviderActive()` (409) |
-| 17  | Catálogo OpenRouter dinámico              | Los modelos OpenRouter no están hardcoded — se obtienen de la API con cache 15min (`libs/openrouter`). Pricing, ranking y presets se construyen dinámicamente |
+| 17  | Catálogo OpenRouter dinámico              | Los modelos OpenRouter no están hardcoded — se obtienen de la API con cache 15min (`libs/openrouter`). Pricing, ranking y presets se construyen dinámicamente                                          |
 
 ---
 

--- a/docs/plans/38-llm-provider-toggle.md
+++ b/docs/plans/38-llm-provider-toggle.md
@@ -1,6 +1,6 @@
 # Plan 38 — Toggle Global de Proveedores LLM + Hardening LLM Pipeline
 
-**Spec:** docs/specs/branches/38-llm-provider-toggle.md (v2.0)  
+**Spec:** docs/specs/branches/38-llm-provider-toggle.md (v3.0)  
 **Branch:** feature/llm-provider-toggle  
 **Depende de:** Spec 35 (openrouter-integration), Spec 37 (role-based-access-separation)
 
@@ -475,49 +475,224 @@ pnpm nx build web
 
 ---
 
+## Fase E — Modelos OpenRouter dinámicos
+
+### E.1 — Crear librería `libs/openrouter`
+
+Usar `nx g @nx/js:library openrouter` para crear la lib. Estructura:
+
+```
+libs/openrouter/
+  src/
+    index.ts              # barrel export
+    lib/
+      openrouter-models.service.ts  # servicio principal con cache
+      openrouter.types.ts           # tipos compartidos
+      openrouter.constants.ts       # categorías, defaults
+```
+
+**Dependencia:** `@openrouter/sdk` (instalar en workspace root)
+
+**`OpenRouterModelsService`:**
+
+```typescript
+export interface OpenRouterModelInfo {
+  id: string;
+  name: string;
+  contextLength: number;
+  maxCompletionTokens: number | null;
+  pricing: { prompt: number; completion: number };
+  isFree: boolean;
+  categories: string[];
+  supportedParameters: string[];
+  description?: string;
+}
+
+export interface OpenRouterModelsFilter {
+  category?: string;
+  freeOnly?: boolean;
+  textOnly?: boolean;
+  supportedParams?: string[];
+}
+
+export class OpenRouterModelsService {
+  private cache: { data: OpenRouterModelInfo[]; fetchedAt: number } | null =
+    null;
+  private readonly CACHE_TTL = 15 * 60 * 1000; // 15 minutes
+
+  async listModels(
+    filter?: OpenRouterModelsFilter,
+  ): Promise<OpenRouterModelInfo[]>;
+  async getFreeModels(): Promise<OpenRouterModelInfo[]>;
+  async getModelById(modelId: string): Promise<OpenRouterModelInfo | null>;
+  async isModelAvailable(modelId: string): Promise<boolean>;
+  invalidateCache(): void;
+}
+```
+
+### E.2 — Backend: nuevo módulo `OpenRouterModule` + endpoint
+
+**Archivo nuevo:** `apps/api/src/openrouter/openrouter.module.ts`
+
+```typescript
+@Module({
+  providers: [OpenRouterModelsApiService],
+  controllers: [OpenRouterModelsController],
+  exports: [OpenRouterModelsApiService],
+})
+export class OpenRouterModule {}
+```
+
+**Archivo nuevo:** `apps/api/src/openrouter/openrouter-models.controller.ts`
+
+```typescript
+@Controller('openrouter')
+@UseGuards(JwtAuthGuard)
+export class OpenRouterModelsController {
+  @Get('models')
+  async getModels(@Query() query: { category?: string; freeOnly?: string })
+}
+```
+
+**Archivo nuevo:** `apps/api/src/openrouter/openrouter-models-api.service.ts`
+
+Wrapper NestJS que usa `OpenRouterModelsService` de `libs/openrouter`.
+
+### E.3 — Refactorizar `model-pricing.ts`
+
+- Eliminar TODAS las entradas de OpenRouter (las que tienen IDs con `/` como `anthropic/claude-sonnet-4.6`)
+- Mantener entradas de providers nativos (CLAUDE, OPENAI, GROQ, GEMINI, MISTRAL, TOGETHER)
+- La info de pricing de OpenRouter viene dinámicamente de la API
+
+### E.4 — Refactorizar `model-ranking.ts`
+
+- Eliminar entradas con `provider: LLMProvider.OPENROUTER` de `MODEL_RANKING[]`
+- Crear función `buildDynamicRanking()` que combina:
+  - `MODEL_RANKING` estático (providers nativos)
+  - Modelos OpenRouter dinámicos convertidos a `ModelRank` con scoring heurístico basado en pricing, context_length, y categoría
+- `suggestModel()` y `suggestModels()` usan el ranking combinado
+
+### E.5 — Refactorizar `agent-presets.ts`
+
+- `PRESET_FREE`, `PRESET_OPTIMIZED`, `PRESET_BALANCED` mantienen IDs estáticos como default
+- Crear función `validatePreset(preset, availableModels)` que verifica cada modelo del preset contra la API
+- Si un modelo no existe → buscar alternativa por categoría/precio similar
+- Esta validación se ejecuta cuando el usuario aplica un preset
+
+### E.6 — Frontend: reemplazar listas hardcoded
+
+**Archivos afectados:**
+
+- `apps/web/src/containers/settings/openrouter-primary-tab.tsx` — eliminar `OPENROUTER_MODELS` hardcoded, usar hook
+- `apps/web/src/components/config/constants.tsx` — eliminar array hardcoded
+- `apps/web/src/components/onboarding/types.ts` — eliminar array hardcoded
+- `apps/web/src/pages/dashboard/settings.tsx` — eliminar array hardcoded
+- `apps/web/src/pages/dashboard/settings/llms.tsx` — eliminar array hardcoded
+
+**Nuevo hook:** `apps/web/src/hooks/use-openrouter-models.ts`
+
+```typescript
+export function useOpenRouterModels(filter?: {
+  category?: string;
+  freeOnly?: boolean;
+}) {
+  return useQuery({
+    queryKey: ['openrouter-models', filter],
+    queryFn: () => api.get('/openrouter/models', { params: filter }),
+    staleTime: 15 * 60 * 1000, // match server cache
+  });
+}
+```
+
+### E.7 — Refactorizar `fetchOpenRouter` en `LLMModelsService`
+
+`apps/api/src/llm/llm-models.service.ts` → `fetchOpenRouter()` ya hace fetch directo con axios. Refactorizar para usar `OpenRouterModelsService` de `libs/openrouter` en vez de duplicar lógica.
+
+### E.8 — Tests
+
+- Test `OpenRouterModelsService`: mock de SDK, cache hit/miss, filtros
+- Test endpoint `GET /openrouter/models`: response shape
+- Test `suggestModel` con ranking dinámico
+- Test `validatePreset` con modelos faltantes
+
+**Verificación Fase E:**
+
+```bash
+pnpm nx test api
+pnpm nx build api
+pnpm nx build web
+```
+
+---
+
 ## Criterios de aceptación
 
 ### Toggle Admin (core)
 
-- [ ] Modelo `PlatformLLMProvider` creado con migración y seed
-- [ ] Admin puede ver tabla con estado de todos los providers en `/admin/llm-providers`
-- [ ] Admin puede toggle on/off cada provider con confirmación
-- [ ] Al desactivar: AgentConfigs limpiados, notificaciones enviadas, AdminAction registrada
-- [ ] `setLLMKey` rechaza providers desactivados con 400
-- [ ] Endpoints LLM-dependientes rechazan providers desactivados con 409
-- [ ] Frontend intercepta 409 y redirige a settings/llms
-- [ ] Cards de providers inactivos aparecen disabled en settings/llms del usuario
-- [ ] Agentes con provider inactivo muestran badge de atención
+- [x] Modelo `PlatformLLMProvider` creado con migración y seed
+- [x] Admin puede ver tabla con estado de todos los providers en `/admin/llm-providers`
+- [x] Admin puede toggle on/off cada provider con confirmación
+- [x] Al desactivar: AgentConfigs limpiados, notificaciones enviadas, AdminAction registrada
+- [x] `setLLMKey` rechaza providers desactivados con 400
+- [x] Endpoints LLM-dependientes rechazan providers desactivados con 409
+- [x] Frontend intercepta 409 y redirige a settings/llms
+- [x] Cards de providers inactivos aparecen disabled en settings/llms del usuario
+- [x] Agentes con provider inactivo muestran badge de atención
 
 ### Fixes Pipeline LLM (P1-P4)
 
-- [ ] P1: `llmApiKey` eliminado de `TradingProcessor` (código muerto removido)
-- [ ] P2: `TradingProcessor` usa `checkHealth(userId)` en vez de `findFirst({ isActive: true })`
-- [ ] P3: `resolveLLMForNews()` eliminado de `MarketService`
-- [ ] P4: `SubAgentService.getProvider()` valida provider activo vía `assertProviderActive()`
+- [x] P1: `llmApiKey` eliminado de `TradingProcessor` (código muerto removido)
+- [x] P2: `TradingProcessor` usa `checkHealth(userId)` en vez de `findFirst({ isActive: true })`
+- [x] P3: `resolveLLMForNews()` eliminado de `MarketService`
+- [x] P4: `SubAgentService.getProvider()` valida provider activo vía `assertProviderActive()`
 
 ### Persistencia sentimiento A2→DB
 
-- [ ] `orchestrateDecision` persiste el sentimiento en `NewsAnalysis` cuando no es cache
-- [ ] `NewsAnalysis.aiAnalyzedAt` refleja la fecha del análisis trading
+- [x] `orchestrateDecision` persiste el sentimiento en `NewsAnalysis` cuando no es cache
+- [x] `NewsAnalysis.aiAnalyzedAt` refleja la fecha del análisis trading
 
 ### TTL análisis noticias C1
 
-- [ ] `analyzeSentiment` verifica `aiAnalyzedAt` vs `intervalMinutes` antes de llamar al LLM
-- [ ] Si el análisis es reciente (trading A2 o manual), retorna el existente sin nueva llamada
+- [x] `analyzeSentiment` verifica `aiAnalyzedAt` vs `intervalMinutes` antes de llamar al LLM
+- [x] Si el análisis es reciente (trading A2 o manual), retorna el existente sin nueva llamada
 
 ### Chat visual B2
 
-- [ ] Evento SSE de routing incluye `provider` y `model`
-- [ ] `useChatAgent` propaga `provider`/`model` del routing event
-- [ ] `AgentHeader` muestra provider/model inmediatamente al cambio de agente
+- [x] Evento SSE de routing incluye `provider` y `model`
+- [x] `useChatAgent` propaga `provider`/`model` del routing event
+- [x] `AgentHeader` muestra provider/model inmediatamente al cambio de agente
+
+### Modelos OpenRouter dinámicos (Fase E)
+
+- [x] Lib `libs/openrouter` creada con `OpenRouterModelsService` y tipos
+- [x] `@openrouter/sdk` instalado en workspace
+- [x] Endpoint `GET /openrouter/models` funcional con cache 15min
+- [x] `model-pricing.ts` sin entradas hardcoded de OpenRouter
+- [x] `model-ranking.ts` sin entradas estáticas de OpenRouter, usa ranking dinámico
+- [x] `agent-presets.ts` tiene validación de disponibilidad de modelos (`buildDynamicPreset` + `resolveFallbackModel`)
+- [x] Frontend: `OPENROUTER_MODELS` eliminado de todos los archivos
+- [x] Frontend: hook `useOpenRouterModels` consume endpoint dinámico
+- [x] `fetchOpenRouter` en `LLMModelsService` usa lib compartida
+- [x] Tests unitarios del servicio de modelos
+
+### Mejoras UX adicionales (Fase F — v4.0)
+
+- [x] SIGMA conclusion bug fix (`effectiveSigma` en news-sentiment-panel y analysis-summary-card)
+- [x] Agent decision model display (`llmProvider`/`llmModel` en DecisionPayload, trading.processor, analytics.service)
+- [x] Vertical tabs layout en settings/agents y admin/agent-models
+- [x] Select auto dropdown direction (up/down)
+- [x] Model name truncation en Select
+- [x] Responsive filters en OpenRouterModelSelect
+- [x] Equal height cards + full-width provider selector
+- [x] ESLint config fix (package.json ignores)
 
 ### General
 
-- [ ] Traducciones completas en.ts + es.ts
-- [ ] Build api + web pasan sin errores
-- [ ] Tests unitarios del service pasan
-- [ ] Todos los procesos LLM usan `AgentConfigResolver` (ver tabla normativa en spec)
+- [x] Traducciones completas en.ts + es.ts
+- [x] Build api + web pasan sin errores
+- [x] Tests unitarios del service pasan (16 suites, 135 tests)
+- [x] Lint pasa en todos los proyectos (10/10, 0 errores)
+- [x] Todos los procesos LLM usan `AgentConfigResolver` (ver tabla normativa en spec)
 
 ---
 
@@ -532,7 +707,7 @@ gh pr create \
   --base main \
   --head feature/llm-provider-toggle \
   --title "feat: Toggle global de proveedores LLM + hardening pipeline — Spec 38" \
-  --body "## Spec 38 — Toggle Global de Proveedores LLM + Hardening LLM Pipeline (v2.0)
+  --body "## Spec 38 — Toggle Global de Proveedores LLM + Hardening LLM Pipeline (v4.0)
 
 ### Cambios principales
 - Nuevo modelo PlatformLLMProvider con seed
@@ -556,12 +731,27 @@ gh pr create \
 - C1 TTL: analyzeSentiment respeta intervalMinutes del usuario
 - B2 visual: Evento SSE routing incluye provider/model para AgentHeader
 
+### Modelos OpenRouter dinámicos (Fase E)
+- Nueva lib libs/openrouter con OpenRouterModelsService + cache 15min
+- Endpoint GET /openrouter/models con filtros
+- Eliminadas todas las entradas hardcoded de OpenRouter en model-pricing/ranking
+- agent-presets con validación dinámica de disponibilidad de modelos
+- Frontend: useOpenRouterModels hook, OPENROUTER_MODELS eliminado
+
+### Mejoras UX adicionales (Fase F — v4.0)
+- SIGMA conclusion bug fix (effectiveSigma derivado de AI analysis)
+- Agent decision model display (llmProvider/llmModel en metadata)
+- Vertical tabs layout en settings/agents y admin/agent-models
+- Select auto dropdown direction + model name truncation
+- Responsive filters en OpenRouterModelSelect
+- ESLint config fix (package.json ignores)
+
 ### i18n
-- Traducciones en/es completas
+- Traducciones en/es completas (incluye agents.agentSwitched)
 
 ### Testing
-- Tests unitarios PlatformLLMProviderService
-- Tests persistencia A2, TTL C1, routing SSE
+- 16 suites, 135 tests — todos pasan
+- Lint 10/10 proyectos — 0 errores
 - Build api ✅ + Build web ✅
 
 Closes #XX"

--- a/docs/specs/branches/38-llm-provider-toggle.md
+++ b/docs/specs/branches/38-llm-provider-toggle.md
@@ -1,15 +1,17 @@
 # Spec 38 — Toggle Global de Proveedores LLM + Hardening LLM Pipeline
 
-**Fecha:** 2026-04-22  
-**Versión:** 2.0  
-**Estado:** Propuesto  
+**Fecha:** 2026-04-23  
+**Versión:** 4.0  
+**Estado:** Implementado  
 **Branch:** `feature/llm-provider-toggle`  
 **Dependencias:** Spec 35 (openrouter-integration), Spec 31 (llm-provider-dashboard), Spec 36 (agent-hub-config)
 
-| Versión | Fecha      | Cambios                                                                                                                    |
-| ------- | ---------- | -------------------------------------------------------------------------------------------------------------------------- |
-| 1.0     | 2026-04-22 | Versión inicial: toggle admin, validaciones, UI admin/user                                                                 |
-| 2.0     | 2026-04-22 | Amplía scope: fixes P1-P4, persistencia de sentimiento A2, chat agent/model header, TTL C1, tabla normativa agente→proceso |
+| Versión | Fecha      | Cambios                                                                                                                                                                                  |
+| ------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.0     | 2026-04-22 | Versión inicial: toggle admin, validaciones, UI admin/user                                                                                                                               |
+| 2.0     | 2026-04-22 | Amplía scope: fixes P1-P4, persistencia de sentimiento A2, chat agent/model header, TTL C1, tabla normativa agente→proceso                                                               |
+| 3.0     | 2026-04-22 | Sección F: modelos OpenRouter dinámicos via SDK, eliminación de hardcodeo, nueva lib `libs/openrouter`                                                                                   |
+| 4.0     | 2026-04-23 | Estado → Implementado. Agrega sección G: mejoras UX adicionales (SIGMA bug, agent model display, vertical tabs, Select auto-direction, responsive filters). Correcciones de lint ESLint. |
 
 ---
 
@@ -50,6 +52,17 @@ Esta spec introduce:
 ### E. Chat: indicador visual de agente/modelo activo (B2)
 
 - En la UI de chat, al cambiar de agente vía routing de KRYPTO, mostrar visualmente el cambio incluyendo el provider/modelo que está respondiendo.
+
+### F. Modelos OpenRouter dinámicos — eliminación de hardcodeo
+
+**Problema:** Los modelos OpenRouter están hardcoded en `model-pricing.ts`, `model-ranking.ts`, `agent-presets.ts` y múltiples archivos frontend. Cuando un modelo se depreca o se revela (ej: `openrouter/elephant-alpha`), todo el sistema rompe con 404.
+
+**Solución:** Reemplazar todas las listas hardcoded de OpenRouter con fetching dinámico via `@openrouter/sdk`:
+
+- **Nueva lib `libs/openrouter`:** Encapsula el SDK de OpenRouter (`@openrouter/sdk`), expone un servicio con cache (TTL 15min) que lista modelos, filtra por categoría/precio, y provee tipos compartidos.
+- **Backend:** Nuevo endpoint `GET /openrouter/models` que proxy-a la API con cache server-side. `model-pricing.ts` y `model-ranking.ts` mantienen datos estáticos solo para providers non-OpenRouter; las entradas de OpenRouter se resuelven dinámicamente.
+- **`agent-presets.ts`:** Los presets validan que los modelos existan contra la API en runtime (fallback a modelo similar si el preset queda obsoleto).
+- **Frontend:** Los selectores de modelo OpenRouter consumen el endpoint dinámico en vez de arrays hardcoded.
 
 ---
 
@@ -480,6 +493,29 @@ subject.next(
 5. **B2 UI:** Propagar `provider`/`model` del evento routing en `useChatAgent` → `AgentHeader`
 6. Traducciones en.ts / es.ts
 
+### Fase E — Modelos OpenRouter dinámicos
+
+1. Crear `libs/openrouter` con servicio de fetching + cache + tipos
+2. Backend: endpoint `GET /openrouter/models` con filtros (category, free, text-only)
+3. Backend: refactorizar `model-pricing.ts` — eliminar entradas hardcoded de OpenRouter
+4. Backend: refactorizar `model-ranking.ts` — entradas OpenRouter se resuelven dinámicamente
+5. Backend: `agent-presets.ts` — validación en runtime de disponibilidad de modelos
+6. Frontend: reemplazar `OPENROUTER_MODELS` hardcoded por fetch dinámico
+7. Frontend: reemplazar listas en `settings.tsx`, `llms.tsx`, `constants.tsx`, `types.ts`
+
+### Fase F — Mejoras UX adicionales (v4.0)
+
+1. **SIGMA conclusion bug fix:** `news-sentiment-panel.tsx` y `analysis-summary-card.tsx` — derivar `effectiveSigma` desde AI analysis (`useNewsAnalysis()`) cuando `hasAi` es true, en vez de leer de metadata de decisiones del agente (que tenía score 0.00).
+2. **Agent decision model display:** Nuevos campos `llmProvider`/`llmModel` en `DecisionPayload`, `trading.processor.ts`, y `analytics.service.ts` — persiste el modelo usado en síntesis para mostrarlo en detalle del agente (en vez de mostrar el modelo fallback).
+3. **Vertical tabs layout:** `/dashboard/settings/agents` y `/admin/agent-models` — reemplazar grid de cards por sidebar vertical con navegación tipo tabs (desktop: sidebar w-48, mobile: Select dropdown).
+4. **Select auto dropdown direction:** `libs/ui/src/lib/composites/select.tsx` — detección automática del espacio disponible para abrir el dropdown hacia arriba o abajo (umbral 280px).
+5. **Model name truncation:** `Select` component — clase CSS `truncate` en label para nombres largos de modelos OpenRouter.
+6. **Responsive filters:** `openrouter-model-select.tsx` — filtros pasan de `grid-cols-3` a `grid-cols-1 sm:grid-cols-3`.
+7. **Equal height cards:** `items-stretch` + `h-full` en contenedores de AgentConfigCard y AdminAgentConfigCard.
+8. **Full-width provider selector:** Eliminado `max-w-[240px]` para que el selector de provider use ancho completo.
+9. **Badge "Requiere atención"** en `/dashboard/settings/agents` — sidebar y mobile Select muestran alerta amber cuando un agente tiene provider desactivado por admin.
+10. **ESLint fix:** `eslint.config.mjs` — ignorar `**/package.json` para evitar parsing error en libs.
+
 ---
 
 ## 12. Out of scope
@@ -495,15 +531,18 @@ subject.next(
 
 ## 13. Decisiones de diseño
 
-| #   | Decisión                                                               | Alternativa                                 | Razón                                                                               |
-| --- | ---------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------- |
-| 1   | Modelo `PlatformLLMProvider` dedicado vs JSON config                   | JSON en tabla de settings                   | Queries eficientes, auditable, extensible                                           |
-| 2   | Validación en endpoints específicos vs Guard global                    | Guard global en todos los endpoints         | Guard global bloquearía settings/profile; solo endpoints LLM necesitan validación   |
-| 3   | Limpiar AgentConfig.provider/model al desactivar vs bloquear ejecución | Solo bloquear sin limpiar                   | Limpiar + notificar es más claro para el usuario; evita estado zombie               |
-| 4   | 409 Conflict para provider disabled vs 403 Forbidden                   | 403                                         | 409 semánticamente correcto (conflicto de estado), 403 implicaría falta de permisos |
-| 5   | Seed automático en migración vs creación on-demand                     | On-demand (crear registro al primer toggle) | Seed garantiza consistencia; todos los providers existen siempre                    |
-| 6   | Notificación tipo `LLM_PROVIDER_DISABLED` vs reusar `AGENT_ERROR`      | Reusar tipo existente                       | Tipo dedicado permite filtrar y personalizar el mensaje/link en frontend            |
-| 7   | Persistir sentimiento A2 en `NewsAnalysis` vs tabla separada           | Tabla dedicada de sentiment cache           | Reusar modelo existente, misma estructura AI ya definida                            |
-| 8   | TTL de análisis AI basado en `intervalMinutes` vs TTL fijo             | TTL hardcoded de 10 min                     | Respetar configuración del usuario; flexibilidad                                    |
-| 9   | Incluir provider/model en evento SSE routing vs solo agentId           | Frontend lo consulta después                | Evita roundtrip extra; dato ya disponible en backend al momento del routing         |
-| 10  | Eliminar `resolveLLMForNews` vs marcar deprecated                      | Solo deprecar                               | Código muerto que puede confundir; eliminarlo es más seguro                         |
+| #   | Decisión                                                               | Alternativa                                 | Razón                                                                                 |
+| --- | ---------------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 1   | Modelo `PlatformLLMProvider` dedicado vs JSON config                   | JSON en tabla de settings                   | Queries eficientes, auditable, extensible                                             |
+| 2   | Validación en endpoints específicos vs Guard global                    | Guard global en todos los endpoints         | Guard global bloquearía settings/profile; solo endpoints LLM necesitan validación     |
+| 3   | Limpiar AgentConfig.provider/model al desactivar vs bloquear ejecución | Solo bloquear sin limpiar                   | Limpiar + notificar es más claro para el usuario; evita estado zombie                 |
+| 4   | 409 Conflict para provider disabled vs 403 Forbidden                   | 403                                         | 409 semánticamente correcto (conflicto de estado), 403 implicaría falta de permisos   |
+| 5   | Seed automático en migración vs creación on-demand                     | On-demand (crear registro al primer toggle) | Seed garantiza consistencia; todos los providers existen siempre                      |
+| 6   | Notificación tipo `LLM_PROVIDER_DISABLED` vs reusar `AGENT_ERROR`      | Reusar tipo existente                       | Tipo dedicado permite filtrar y personalizar el mensaje/link en frontend              |
+| 7   | Persistir sentimiento A2 en `NewsAnalysis` vs tabla separada           | Tabla dedicada de sentiment cache           | Reusar modelo existente, misma estructura AI ya definida                              |
+| 8   | TTL de análisis AI basado en `intervalMinutes` vs TTL fijo             | TTL hardcoded de 10 min                     | Respetar configuración del usuario; flexibilidad                                      |
+| 9   | Incluir provider/model en evento SSE routing vs solo agentId           | Frontend lo consulta después                | Evita roundtrip extra; dato ya disponible en backend al momento del routing           |
+| 10  | Eliminar `resolveLLMForNews` vs marcar deprecated                      | Solo deprecar                               | Código muerto que puede confundir; eliminarlo es más seguro                           |
+| 11  | Lib `libs/openrouter` dedicada vs integrar en `libs/analysis`          | Añadir al módulo analysis existente         | Separación de responsabilidades; openrouter tiene SDK propio, tipos, cache propia     |
+| 12  | SDK `@openrouter/sdk` vs REST directo con axios                        | axios a `/api/v1/models`                    | SDK provee tipos TypeScript, validación Zod, mantiene paridad con API automáticamente |
+| 13  | Cache server-side 15min vs cache frontend-only                         | Solo cache en React Query                   | Backend como proxy permite compartir cache entre usuarios, reduce calls a OpenRouter  |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ export default [
       '**/out-tsc',
       '**/vite.config.*.timestamp*',
       '**/vitest.config.*.timestamp*',
+      '**/package.json',
     ],
   },
   {
@@ -29,13 +30,6 @@ export default [
         },
       ],
       // All libs are private/internal — dependencies are managed at the root level
-      '@nx/dependency-checks': 'off',
-    },
-  },
-  {
-    // Disable dependency-checks for private lib package.json files
-    files: ['libs/*/package.json'],
-    rules: {
       '@nx/dependency-checks': 'off',
     },
   },

--- a/libs/openrouter/package.json
+++ b/libs/openrouter/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@crypto-trader/openrouter",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "dependencies": {}
+}

--- a/libs/openrouter/project.json
+++ b/libs/openrouter/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "openrouter",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/openrouter/src",
+  "projectType": "library",
+  "tags": [],
+  "// targets": "to see all targets run: nx show project openrouter --web",
+  "targets": {}
+}

--- a/libs/openrouter/src/index.ts
+++ b/libs/openrouter/src/index.ts
@@ -1,0 +1,6 @@
+export { OpenRouterModelsService } from './lib/openrouter-models.service';
+export type {
+  OpenRouterModelInfo,
+  OpenRouterModelsFilter,
+} from './lib/openrouter.types';
+export { OPENROUTER_DEFAULT_CACHE_TTL } from './lib/openrouter.constants';

--- a/libs/openrouter/src/lib/openrouter-models.service.ts
+++ b/libs/openrouter/src/lib/openrouter-models.service.ts
@@ -1,0 +1,124 @@
+import { OpenRouter } from '@openrouter/sdk';
+import type {
+  OpenRouterModelInfo,
+  OpenRouterModelsFilter,
+} from './openrouter.types';
+import { OPENROUTER_DEFAULT_CACHE_TTL } from './openrouter.constants';
+
+interface CacheEntry {
+  data: OpenRouterModelInfo[];
+  fetchedAt: number;
+}
+
+export class OpenRouterModelsService {
+  private cache: Map<string, CacheEntry> = new Map();
+  private readonly cacheTTL: number;
+  private readonly client: OpenRouter;
+
+  constructor(options?: { cacheTTL?: number }) {
+    this.cacheTTL = options?.cacheTTL ?? OPENROUTER_DEFAULT_CACHE_TTL;
+    // models.list is a public endpoint — no API key needed for listing
+    this.client = new OpenRouter({ apiKey: '' });
+  }
+
+  async listModels(
+    filter?: OpenRouterModelsFilter,
+  ): Promise<OpenRouterModelInfo[]> {
+    const cacheKey = this.buildCacheKey(filter);
+    const cached = this.cache.get(cacheKey);
+    if (cached && Date.now() - cached.fetchedAt < this.cacheTTL) {
+      return cached.data;
+    }
+
+    const response = await this.client.models.list({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      category: filter?.category as any,
+      outputModalities: filter?.textOnly !== false ? 'text' : undefined,
+    });
+
+    let models = (response.data ?? [])
+      .filter((m) => {
+        // Exclude models with expiration dates (about to be deprecated)
+        if ('expirationDate' in m && m.expirationDate) return false;
+        return true;
+      })
+      .map((m): OpenRouterModelInfo => {
+        const promptPrice = parseFloat(m.pricing.prompt) * 1_000_000;
+        const completionPrice = parseFloat(m.pricing.completion) * 1_000_000;
+        const isFree = promptPrice === 0 && completionPrice === 0;
+
+        const supportedParams = m.supportedParameters.map((p) =>
+          typeof p === 'string' ? p : String(p),
+        );
+
+        const categories: string[] = [];
+        if (isFree) categories.push('free');
+        if (!isFree) categories.push('paid');
+        if (
+          supportedParams.includes('reasoning') ||
+          supportedParams.includes('include_reasoning')
+        ) {
+          categories.push('reasoning');
+        }
+        if (supportedParams.includes('tools')) {
+          categories.push('tool-use');
+        }
+        if ((promptPrice < 1.0 && completionPrice < 5.0) || isFree) {
+          categories.push('fast');
+        }
+        const ctxLen = m.contextLength ?? 128_000;
+        if (ctxLen >= 200_000) {
+          categories.push('long-context');
+        }
+        if (!isFree && completionPrice >= 10) {
+          categories.push('premium');
+        }
+
+        return {
+          id: m.id,
+          name: m.name,
+          contextLength: m.contextLength ?? 128_000,
+          maxCompletionTokens: m.topProvider.maxCompletionTokens ?? null,
+          pricing: { prompt: promptPrice, completion: completionPrice },
+          isFree,
+          categories,
+          supportedParameters: supportedParams,
+          description: m.description,
+        };
+      });
+
+    if (filter?.freeOnly) {
+      models = models.filter((m) => m.isFree);
+    }
+
+    this.cache.set(cacheKey, { data: models, fetchedAt: Date.now() });
+    return models;
+  }
+
+  async getFreeModels(): Promise<OpenRouterModelInfo[]> {
+    return this.listModels({ freeOnly: true });
+  }
+
+  async getModelById(modelId: string): Promise<OpenRouterModelInfo | null> {
+    const allModels = await this.listModels();
+    return allModels.find((m) => m.id === modelId) ?? null;
+  }
+
+  async isModelAvailable(modelId: string): Promise<boolean> {
+    const model = await this.getModelById(modelId);
+    return model !== null;
+  }
+
+  invalidateCache(): void {
+    this.cache.clear();
+  }
+
+  private buildCacheKey(filter?: OpenRouterModelsFilter): string {
+    if (!filter) return 'all';
+    const parts: string[] = [];
+    if (filter.category) parts.push(`cat:${filter.category}`);
+    if (filter.freeOnly) parts.push('free');
+    if (filter.textOnly !== undefined) parts.push(`text:${filter.textOnly}`);
+    return parts.length ? parts.join('|') : 'all';
+  }
+}

--- a/libs/openrouter/src/lib/openrouter.constants.ts
+++ b/libs/openrouter/src/lib/openrouter.constants.ts
@@ -1,0 +1,2 @@
+/** Server-side cache TTL: 15 minutes */
+export const OPENROUTER_DEFAULT_CACHE_TTL = 15 * 60 * 1000;

--- a/libs/openrouter/src/lib/openrouter.types.ts
+++ b/libs/openrouter/src/lib/openrouter.types.ts
@@ -1,0 +1,17 @@
+export interface OpenRouterModelInfo {
+  id: string;
+  name: string;
+  contextLength: number;
+  maxCompletionTokens: number | null;
+  pricing: { prompt: number; completion: number };
+  isFree: boolean;
+  categories: string[];
+  supportedParameters: string[];
+  description?: string;
+}
+
+export interface OpenRouterModelsFilter {
+  category?: string;
+  freeOnly?: boolean;
+  textOnly?: boolean;
+}

--- a/libs/openrouter/tsconfig.json
+++ b/libs/openrouter/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/openrouter/tsconfig.lib.json
+++ b/libs/openrouter/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx"
+  ]
+}

--- a/libs/openrouter/tsconfig.spec.json
+++ b/libs/openrouter/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -119,6 +119,11 @@ export { DecisionFlowDiagram } from './lib/domain/agent/decision-flow-diagram';
 export { ExplainPanel } from './lib/domain/agent/explain-panel';
 export { ParameterCards } from './lib/domain/agent/parameter-cards';
 export { StrategyPresets, PRESETS } from './lib/domain/agent/strategy-presets';
+export { ModelInfoModal } from './lib/domain/agent/model-info-modal';
+export type {
+  ModelInfoModalProps,
+  ModelInfoData,
+} from './lib/domain/agent/model-info-modal';
 
 // Domain — Chat
 export type {

--- a/libs/ui/src/lib/composites/dialog.tsx
+++ b/libs/ui/src/lib/composites/dialog.tsx
@@ -10,7 +10,7 @@ interface DialogProps {
   onClose: () => void;
   title: string;
   description?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   size?: 'sm' | 'md' | 'lg';
   variant?: DialogVariant;
   /** For confirm/danger variants */

--- a/libs/ui/src/lib/composites/select.tsx
+++ b/libs/ui/src/lib/composites/select.tsx
@@ -37,9 +37,21 @@ export function Select({
 }: SelectProps) {
   const [open, setOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
+  const [dropUp, setDropUp] = React.useState(false);
   const ref = React.useRef<HTMLDivElement>(null);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
   const searchRef = React.useRef<HTMLInputElement>(null);
   const selected = options.find((o) => o.value === value);
+
+  // Detect if dropdown should open upward
+  React.useEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    const dropdownHeight = 280; // max-h-60 (240px) + search bar + margin
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    setDropUp(spaceBelow < dropdownHeight && spaceAbove > spaceBelow);
+  }, [open]);
 
   React.useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -83,6 +95,7 @@ export function Select({
       )}
       <div className="relative">
         <button
+          ref={triggerRef}
           type="button"
           disabled={disabled}
           onClick={() => setOpen(!open)}
@@ -95,7 +108,12 @@ export function Select({
         >
           <span className="flex items-center gap-2 truncate">
             {selected?.icon}
-            <span className={cn(!selected && 'text-muted-foreground/60')}>
+            <span
+              className={cn(
+                'truncate',
+                !selected && 'text-muted-foreground/60',
+              )}
+            >
               {selected?.label ?? placeholder}
             </span>
           </span>
@@ -108,7 +126,14 @@ export function Select({
         </button>
 
         {open && (
-          <div className="absolute z-50 mt-1.5 w-full overflow-hidden rounded-lg border border-border bg-card shadow-lg animate-in fade-in-0 zoom-in-95 slide-in-from-top-2">
+          <div
+            className={cn(
+              'absolute z-50 w-full overflow-hidden rounded-lg border border-border bg-card shadow-lg animate-in fade-in-0 zoom-in-95',
+              dropUp
+                ? 'bottom-full mb-1.5 slide-in-from-bottom-2'
+                : 'top-full mt-1.5 slide-in-from-top-2',
+            )}
+          >
             {searchable && (
               <div className="flex items-center gap-2 border-b border-border px-2.5 py-2">
                 <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />

--- a/libs/ui/src/lib/domain/agent/model-info-modal.tsx
+++ b/libs/ui/src/lib/domain/agent/model-info-modal.tsx
@@ -1,0 +1,206 @@
+import * as React from 'react';
+import { Dialog } from '../../composites/dialog';
+import { cn } from '../../utils';
+
+export interface ModelInfoData {
+  id: string;
+  name: string;
+  contextLength: number;
+  maxCompletionTokens?: number | null;
+  pricing: { prompt: number; completion: number };
+  isFree: boolean;
+  categories: string[];
+  supportedParameters: string[];
+  description?: string;
+}
+
+export interface ModelInfoModalProps {
+  open: boolean;
+  onClose: () => void;
+  model: ModelInfoData | null;
+}
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(0)}K`;
+  return String(tokens);
+}
+
+function formatPrice(pricePerMillion: number): string {
+  if (pricePerMillion === 0) return 'Free';
+  if (pricePerMillion < 0.01) return `$${pricePerMillion.toFixed(4)}/M`;
+  if (pricePerMillion < 0.1) return `$${pricePerMillion.toFixed(3)}/M`;
+  if (pricePerMillion < 1) return `$${pricePerMillion.toFixed(2)}/M`;
+  return `$${pricePerMillion.toFixed(1)}/M`;
+}
+
+function Badge({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-md px-2 py-0.5 text-[11px] font-medium',
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  free: 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20',
+  paid: 'bg-amber-500/10 text-amber-400 border border-amber-500/20',
+  reasoning: 'bg-violet-500/10 text-violet-400 border border-violet-500/20',
+  'tool-use': 'bg-blue-500/10 text-blue-400 border border-blue-500/20',
+  fast: 'bg-cyan-500/10 text-cyan-400 border border-cyan-500/20',
+  'long-context':
+    'bg-indigo-500/10 text-indigo-400 border border-indigo-500/20',
+  premium: 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/20',
+};
+
+const PARAM_COLORS: Record<string, string> = {
+  reasoning: 'bg-violet-500/10 text-violet-400',
+  tools: 'bg-blue-500/10 text-blue-400',
+  include_reasoning: 'bg-violet-500/10 text-violet-300',
+  temperature: 'bg-slate-500/10 text-slate-400',
+  top_p: 'bg-slate-500/10 text-slate-400',
+  top_k: 'bg-slate-500/10 text-slate-400',
+  frequency_penalty: 'bg-slate-500/10 text-slate-400',
+  presence_penalty: 'bg-slate-500/10 text-slate-400',
+  repetition_penalty: 'bg-slate-500/10 text-slate-400',
+  max_tokens: 'bg-slate-500/10 text-slate-400',
+  stop: 'bg-slate-500/10 text-slate-400',
+};
+
+export function ModelInfoModal({ open, onClose, model }: ModelInfoModalProps) {
+  if (!model) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={model.name}
+      description={model.id}
+      size="lg"
+    >
+      <div className="space-y-5">
+        {/* Description */}
+        {model.description && (
+          <div className="max-h-24 overflow-y-auto rounded-lg border border-border bg-muted/20 p-3">
+            <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
+              {model.description}
+            </p>
+          </div>
+        )}
+
+        {/* Key stats grid */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <div className="rounded-lg border border-border bg-muted/30 p-3 text-center">
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+              Context
+            </p>
+            <p className="text-sm font-bold text-foreground">
+              {formatTokens(model.contextLength)}
+            </p>
+          </div>
+          {model.maxCompletionTokens && (
+            <div className="rounded-lg border border-border bg-muted/30 p-3 text-center">
+              <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+                Max Output
+              </p>
+              <p className="text-sm font-bold text-foreground">
+                {formatTokens(model.maxCompletionTokens)}
+              </p>
+            </div>
+          )}
+          <div className="rounded-lg border border-border bg-muted/30 p-3 text-center">
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+              Input Price
+            </p>
+            <p
+              className={cn(
+                'text-sm font-bold',
+                model.isFree ? 'text-emerald-400' : 'text-foreground',
+              )}
+            >
+              {formatPrice(model.pricing.prompt)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-muted/30 p-3 text-center">
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+              Output Price
+            </p>
+            <p
+              className={cn(
+                'text-sm font-bold',
+                model.isFree ? 'text-emerald-400' : 'text-foreground',
+              )}
+            >
+              {formatPrice(model.pricing.completion)}
+            </p>
+          </div>
+        </div>
+
+        {/* Categories */}
+        {model.categories.length > 0 && (
+          <div>
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+              Categories
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {model.categories.map((cat) => (
+                <Badge
+                  key={cat}
+                  className={
+                    CATEGORY_COLORS[cat] ??
+                    'bg-muted text-muted-foreground border border-border'
+                  }
+                >
+                  {cat.replace(/-/g, ' ')}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Supported parameters */}
+        {model.supportedParameters.length > 0 && (
+          <div>
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+              Supported Parameters
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {model.supportedParameters.map((param) => (
+                <Badge
+                  key={String(param)}
+                  className={
+                    PARAM_COLORS[String(param)] ??
+                    'bg-muted/50 text-muted-foreground'
+                  }
+                >
+                  {String(param)}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Model ID (copyable) */}
+        <div className="rounded-lg border border-border bg-muted/20 p-3">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+            Model ID
+          </p>
+          <code className="text-xs text-foreground font-mono break-all select-all">
+            {model.id}
+          </code>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@nestjs/platform-socket.io": "^11.1.17",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/websockets": "^11.1.17",
+    "@openrouter/sdk": "^0.12.20",
     "@prisma/adapter-pg": "^7.6.0",
     "@prisma/client": "^7.6.0",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@nestjs/websockets':
         specifier: ^11.1.17
         version: 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/platform-socket.io@11.1.17)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@openrouter/sdk':
+        specifier: ^0.12.20
+        version: 0.12.20
       '@prisma/adapter-pg':
         specifier: ^7.6.0
         version: 7.6.0
@@ -2136,6 +2139,9 @@ packages:
 
   '@nx/workspace@22.6.3':
     resolution: {integrity: sha512-Tdu3K6mpRAU0LI2gpi61WLY7mPR61nj1Szvhwj4T88PhGQXSlN6PuUhb5nMPHnZG/bDmUFeTSv/+MCgbEm563A==}
+
+  '@openrouter/sdk@0.12.20':
+    resolution: {integrity: sha512-5CrbvQS/02sko455TIpzieHnYwDYH+bn7bn+CS/5d/2YtTGOhyI5yq2jIn/ux2poeNg62vGuUA2dNNeCyfIo2A==}
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
@@ -11785,6 +11791,10 @@ snapshots:
       - '@swc-node/register'
       - '@swc/core'
       - debug
+
+  '@openrouter/sdk@0.12.20':
+    dependencies:
+      zod: 4.3.6
 
   '@oxc-project/types@0.122.0': {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,6 +22,7 @@
       "@crypto-trader/analysis": ["libs/analysis/src/index.ts"],
       "@crypto-trader/data-fetcher": ["libs/data-fetcher/src/index.ts"],
       "@crypto-trader/ui": ["libs/ui/src/index.ts"],
+      "@crypto-trader/openrouter": ["libs/openrouter/src/index.ts"],
       "shared": ["libs/shared/src/index.ts"],
       "trading-engine": ["libs/trading-engine/src/index.ts"],
       "analysis": ["libs/analysis/src/index.ts"],


### PR DESCRIPTION
## Spec 38 — Toggle Global de Proveedores LLM + Hardening LLM Pipeline (v4.0)

### Resumen
Feature completa implementada en 6 fases (A→F):
- **Fase A:** Modelo PlatformLLMProvider + API admin + seed + fixes P1-P3
- **Fase B:** Pipeline hardening + sentimiento persistence + TTL
- **Fase C+D:** Panel admin + UX usuario + chat routing visual
- **Fase E:** OpenRouter dynamic models lib + API + refactor pricing/ranking/presets
- **Fase F:** SIGMA fix + agent decision display + settings UX polish

---

### Cambios principales

#### Toggle Admin (core)
- Nuevo modelo `PlatformLLMProvider` con seed de 7 providers
- API admin: `GET/PUT /admin/llm-providers` con toggle + confirmación
- API user: `GET /llm-providers/status` para ver providers activos
- Validación en `setLLMKey` + todos los endpoints LLM-dependientes
- Panel admin con DataTable + switch + diálogo de impacto
- Cards deshabilitadas en settings/llms del usuario
- Badge "requiere atención" en settings/agents
- Interceptor HTTP 409 → redirect a settings/llms
- Notificaciones push al desactivar provider (1 por usuario afectado)

#### Fixes Pipeline LLM (P1-P4)
- **P1:** Eliminado `llmApiKey` muerto en TradingProcessor (código nunca usado)
- **P2:** TradingProcessor usa `checkHealth(userId)` agent-aware
- **P3:** Eliminado `resolveLLMForNews()` legacy en MarketService
- **P4:** `SubAgentService.getProvider()` valida provider activo vía `assertProviderActive()`

#### Mejoras Pipeline
- **A2→DB:** Sentimiento de trading persistido en NewsAnalysis
- **C1 TTL:** `analyzeSentiment` respeta `intervalMinutes` del usuario
- **B2 visual:** Evento SSE routing incluye provider/model para AgentHeader inmediato

#### Modelos OpenRouter dinámicos (Fase E)
- Nueva lib `libs/openrouter` con `OpenRouterModelsService` + cache 15min
- Endpoint `GET /openrouter/models` con filtros (category, freeOnly)
- `@openrouter/sdk` instalado en workspace
- Eliminadas TODAS las entradas hardcoded de OpenRouter en `model-pricing.ts` y `model-ranking.ts`
- `agent-presets.ts` con `buildDynamicPreset()` + `resolveFallbackModel()` para validación dinámica
- `LLMModelsService.fetchOpenRouter()` usa lib compartida
- Frontend: `useOpenRouterModels` hook + `OpenRouterModelSelect` component
- Eliminado `OPENROUTER_MODELS` hardcoded de constants, types, settings, llms

#### Mejoras UX (Fase F — v4.0)
- SIGMA conclusion bug fix (`effectiveSigma` derivado de AI analysis)
- Agent decision model display (`llmProvider/llmModel` en DecisionPayload)
- Vertical tabs layout en settings/agents y admin/agent-models
- Select auto dropdown direction (up/down basado en viewport)
- Model name truncation en Select para nombres largos
- ModelInfoModal en libs/ui para detalles de modelo
- Responsive filters en OpenRouterModelSelect
- ESLint config fix (package.json ignores)

#### i18n
- Traducciones completas en.ts + es.ts para todas las features nuevas

---

### Testing & Verificación
- ✅ **16 test suites, 135 tests** — todos pasan
- ✅ **Lint 10/10 proyectos** — 0 errores (solo warnings pre-existentes)
- ✅ **Build api** — webpack compiled successfully
- ✅ **Build web** — vite built successfully

### Archivos nuevos
- `libs/openrouter/` — librería compartida de modelos OpenRouter
- `apps/api/src/openrouter/` — módulo NestJS para endpoint de modelos
- `apps/web/src/hooks/use-openrouter-models.ts` — hook de modelos dinámicos
- `apps/web/src/containers/settings/openrouter-model-select.tsx` — componente select
- `libs/ui/src/lib/domain/agent/model-info-modal.tsx` — modal de info de modelo
- `apps/api/src/agents/agent-presets.spec.ts` — tests de presets dinámicos

### Commits (9)
1. `feat(api): Fase A` — PlatformLLMProvider model, API admin, seed, fixes P1-P3
2. `feat(api): Fase B` — pipeline hardening + sentiment persistence + TTL
3. `feat(web): Fase C+D` — admin provider panel + user UX + chat routing
4. `feat(api): Fase E` — dynamic OpenRouter models lib + API + refactor
5. `feat(web): Fase E` — dynamic OpenRouter model selection + remove hardcoded
6. `feat(api): Fase F` — agent decision model display + pipeline enhancements
7. `feat(web): Fase F` — SIGMA fix + settings UX improvements
8. `feat(ui): Select + ModelInfoModal` — UI component improvements
9. `docs: Spec/Plan v4.0 + ESLint fix`